### PR TITLE
Remove the defaults for StorageClass

### DIFF
--- a/api/v1beta1/swift_types.go
+++ b/api/v1beta1/swift_types.go
@@ -53,7 +53,7 @@ type SwiftSpec struct {
 	// Storage class. This is passed to SwiftStorage unless
 	// storageClass is explicitly set for the SwiftStorage.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:default=local-storage
+	// +kubebuilder:default=""
 	StorageClass string `json:"storageClass"`
 }
 

--- a/api/v1beta1/swiftstorage_types.go
+++ b/api/v1beta1/swiftstorage_types.go
@@ -32,8 +32,8 @@ type SwiftStorageSpec struct {
 	Replicas int32 `json:"replicas"`
 
 	// +kubebuilder:validation:Required
-	// +kubebuilder:default=local-storage
 	// Name of StorageClass to use for Swift PVs
+	// +kubebuilder:default=""
 	StorageClass string `json:"storageClass"`
 
 	// +kubebuilder:validation:Required

--- a/config/crd/bases/swift.openstack.org_swifts.yaml
+++ b/config/crd/bases/swift.openstack.org_swifts.yaml
@@ -45,7 +45,7 @@ spec:
             description: SwiftSpec defines the desired state of Swift
             properties:
               storageClass:
-                default: local-storage
+                default: ""
                 description: Storage class. This is passed to SwiftStorage unless
                   storageClass is explicitly set for the SwiftStorage.
                 type: string
@@ -147,7 +147,7 @@ spec:
                     format: int32
                     type: integer
                   storageClass:
-                    default: local-storage
+                    default: ""
                     description: Name of StorageClass to use for Swift PVs
                     type: string
                   storageRequest:

--- a/config/crd/bases/swift.openstack.org_swiftstorages.yaml
+++ b/config/crd/bases/swift.openstack.org_swiftstorages.yaml
@@ -63,7 +63,7 @@ spec:
                 format: int32
                 type: integer
               storageClass:
-                default: local-storage
+                default: ""
                 description: Name of StorageClass to use for Swift PVs
                 type: string
               storageRequest:


### PR DESCRIPTION
As we check for StorageClass="" the defaulting won't work in the webhook.