### PR TITLE
Standardize Swift CRD reconcile

### DIFF
--- a/api/v1beta1/swift_types.go
+++ b/api/v1beta1/swift_types.go
@@ -105,11 +105,9 @@ func (instance Swift) RbacResourceName() string {
 	return "swift-" + instance.Name
 }
 
-// IsReady - returns true if all subresources Ready condition is true
+// IsReady - returns true if Swift is reconciled successfully
 func (instance Swift) IsReady() bool {
-	return instance.Status.Conditions.IsTrue(SwiftRingReadyCondition) &&
-		instance.Status.Conditions.IsTrue(SwiftStorageReadyCondition) &&
-		instance.Status.Conditions.IsTrue(SwiftProxyReadyCondition)
+	return instance.Status.Conditions.IsTrue(condition.ReadyCondition)
 }
 
 // SetupDefaults - initializes any CRD field defaults based on environment variables (the defaulting mechanism itself is implemented via webhooks)


### PR DESCRIPTION
An initial standardization of the `Swift` CRD's reconcile loop to better conform to the pattern we are using across the operators.  This can then be used to inform further standardization of the remaining CRDs.