### PR TITLE
Remove openstack from workflow name

### DIFF
--- a/.github/workflows/build-swift-operator.yaml
+++ b/.github/workflows/build-swift-operator.yaml
@@ -1,4 +1,4 @@
-name: OpenStackSwift Operator image builder
+name: Swift Operator image builder
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
The image name/repo name for swift operator doesn't have openstack in its name. Removing openstack name so that we can sort github status list correctly [1].

[1] https://github.com/gibizer/openstack-k8s-status/tree/main