### PR TITLE
Ctrl manager labels for webhooks and logging

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: swift-controller-manager
+    control-plane: controller-manager
   name: system
 ---
 apiVersion: apps/v1
@@ -11,22 +11,20 @@ metadata:
   name: controller-manager
   namespace: system
   labels:
-    control-plane: swift-controller-manager
-    app.kubernetes.io/name: swift-operator
-    app.kubernetes.io/component: swift
+    control-plane: controller-manager
+    openstack.org/operator-name: swift
 spec:
   selector:
     matchLabels:
-      control-plane: swift-controller-manager
+      openstack.org/operator-name: swift
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: swift-controller-manager
-        app.kubernetes.io/name: swift-operator
-        app.kubernetes.io/component: swift
+        control-plane: controller-manager
+        openstack.org/operator-name: swift
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -12,4 +12,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: controller-manager
+    openstack.org/operator-name: swift

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -17,4 +17,4 @@ spec:
       protocol: TCP
       targetPort: 9443
   selector:
-    control-plane: swift-controller-manager
+    openstack.org/operator-name: swift


### PR DESCRIPTION
We now have a final form for operator controller-manager pod labeling of the format `openstack.org/operator-name: <operator name>` and are no longer relying on the inconsistent labels created by various `operator-sdk` versions.  All operators that lack this standardized pattern are being updated.