### PR TITLE
Revert "Remove config/manager/kustomization.yaml from .gitignore"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ testbin/*
 #Operator SDK generated files
 /bundle/
 bundle.Dockerfile
+config/manager/kustomization.yaml
 
 # editor and IDE paraphernalia
 .idea


### PR DESCRIPTION
This reverts commit 0a1508e7282ff0c374b5e8fae60e85f597025d08.

Reason for revert:
The file should be kept in .gitignore, so that any update made by `make bundle` is not pulled into a git commit.