### PR TITLE
Delete pvcs when statefuleset is deleted

### DIFF
--- a/pkg/swiftstorage/statefulset.go
+++ b/pkg/swiftstorage/statefulset.go
@@ -231,6 +231,10 @@ func StatefulSet(
 					},
 				},
 			}},
+			PersistentVolumeClaimRetentionPolicy: &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+				WhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+				WhenScaled:  appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+			},
 		},
 	}
 }


### PR DESCRIPTION
We don't have to retain the pvcs when the statefulset is deleted. Retaining the associated pvs in case of deletion of pvcs would be decided by the storageClass.