### PR TITLE
Limit minimum value for Replicas spec

### DIFF
--- a/api/v1beta1/swiftproxy_types.go
+++ b/api/v1beta1/swiftproxy_types.go
@@ -36,6 +36,7 @@ type PasswordSelector struct {
 type SwiftProxySpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default=1
+	// +kubebuilder:validation:Minimum=0
 	// Replicas of Swift Proxy
 	Replicas *int32 `json:"replicas"`
 

--- a/api/v1beta1/swiftring_types.go
+++ b/api/v1beta1/swiftring_types.go
@@ -36,6 +36,7 @@ type SwiftRingSpec struct {
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default=1
+	// +kubebuilder:validation:Minimum=1
 	// Number of Swift object replicas (=copies)
 	RingReplicas *int64 `json:"ringReplicas"`
 

--- a/api/v1beta1/swiftstorage_types.go
+++ b/api/v1beta1/swiftstorage_types.go
@@ -28,6 +28,7 @@ import (
 type SwiftStorageSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default=1
+	// +kubebuilder:validation:Minimum=0
 	Replicas *int32 `json:"replicas"`
 
 	// +kubebuilder:validation:Required

--- a/config/crd/bases/swift.openstack.org_swiftproxies.yaml
+++ b/config/crd/bases/swift.openstack.org_swiftproxies.yaml
@@ -66,6 +66,7 @@ spec:
                 default: 1
                 description: Replicas of Swift Proxy
                 format: int32
+                minimum: 0
                 type: integer
               secret:
                 default: osp-secret

--- a/config/crd/bases/swift.openstack.org_swiftrings.yaml
+++ b/config/crd/bases/swift.openstack.org_swiftrings.yaml
@@ -51,6 +51,7 @@ spec:
                 default: 1
                 description: Number of Swift object replicas (=copies)
                 format: int64
+                minimum: 1
                 type: integer
               swiftConfSecret:
                 default: swift-conf

--- a/config/crd/bases/swift.openstack.org_swifts.yaml
+++ b/config/crd/bases/swift.openstack.org_swifts.yaml
@@ -79,6 +79,7 @@ spec:
                     default: 1
                     description: Replicas of Swift Proxy
                     format: int32
+                    minimum: 0
                     type: integer
                   secret:
                     default: osp-secret
@@ -113,6 +114,7 @@ spec:
                     default: 1
                     description: Number of Swift object replicas (=copies)
                     format: int64
+                    minimum: 1
                     type: integer
                   swiftConfSecret:
                     default: swift-conf
@@ -145,6 +147,7 @@ spec:
                   replicas:
                     default: 1
                     format: int32
+                    minimum: 0
                     type: integer
                   storageClass:
                     default: ""

--- a/config/crd/bases/swift.openstack.org_swiftstorages.yaml
+++ b/config/crd/bases/swift.openstack.org_swiftstorages.yaml
@@ -62,6 +62,7 @@ spec:
               replicas:
                 default: 1
                 format: int32
+                minimum: 0
                 type: integer
               storageClass:
                 default: ""


### PR DESCRIPTION
... to reject any invalid values such as negative ones.

Because using 0 replicas for swift data is not a valid use case, this limits the minimum value of RingReplicas to 1 instead of 0.