### PR TITLE
Support disconnected network environments

### DIFF
--- a/.github/create_bundle.sh
+++ b/.github/create_bundle.sh
@@ -1,70 +1,13 @@
 #!/bin/bash
 set -e
 
-CLUSTER_BUNDLE_FILE="bundle/manifests/swift-operator.clusterserviceversion.yaml"
-
 echo "Creating swift operator bundle"
 cd ..
 echo "${GITHUB_SHA}"
 echo "${BASE_IMAGE}"
-skopeo --version
-
-echo "Calculating image digest for docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA}"
-DIGEST=$(skopeo inspect docker://${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} | jq '.Digest' -r)
-# Output:
-# Calculating image digest for docker://quay.io/openstack-k8s-operators/swift-operator:d03f2c1c362c04fc5ef819f92a218f9ea59bbd0c
-# Digest: sha256:1d5b578fd212f8dbd03c0235f1913ef738721766f8c94236af5efecc6d8d8cb1
-echo "Digest: ${DIGEST}"
 
 RELEASE_VERSION=$(grep "^VERSION" Makefile | awk -F'?= ' '{ print $2 }')
-IMAGE_TAG_BASE=$(grep "^IMAGE_TAG_BASE" Makefile | awk -F'?= ' '{ print $2 }')
-OPERATOR_IMG_WITH_DIGEST="${REGISTRY}/${BASE_IMAGE}@${DIGEST}"
-
-echo "New Operator Image with Digest: $OPERATOR_IMG_WITH_DIGEST"
 echo "Release Version: $RELEASE_VERSION"
 
 echo "Creating bundle image..."
-VERSION=$RELEASE_VERSION IMG=$OPERATOR_IMG_WITH_DIGEST make bundle
-
-echo "Bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
-
-# We do not want to exit here. Some images are in different registries, so
-# error will be reported to the console.
-set +e
-for csv_image in $(cat "${CLUSTER_BUNDLE_FILE}" | grep "image:" | sed -e "s|.*image:||" | sort -u); do
-    digest_image=""
-    echo "CSV line: ${csv_image}"
-
-    # case where @ is in the csv_image image
-    if [[ "$csv_image" =~ .*"@".* ]]; then
-        delimeter='@'
-    else
-        delimeter=':'
-    fi
-
-    base_image=$(echo $csv_image | cut -f 1 -d${delimeter})
-    tag_image=$(echo $csv_image | cut -f 2 -d${delimeter})
-
-    if [[ "$base_image:$tag_image" == "$IMAGE_TAG_BASE:latest" ]]; then
-        echo "$base_image:$tag_image becomes $OPERATOR_IMG_WITH_DIGEST"
-        sed -e "s|$base_image:$tag_image|$OPERATOR_IMG_WITH_DIGEST|g" -i "${CLUSTER_BUNDLE_FILE}"
-    else
-        digest_image=$(skopeo inspect docker://${base_image}${delimeter}${tag_image} | jq '.Digest' -r)
-        echo "Base image: $base_image"
-        if [ -n "$digest_image" ]; then
-            echo "$base_image${delimeter}$tag_image becomes $base_image@$digest_image"
-            sed -i "s|$base_image$delimeter$tag_image|$base_image@$digest_image|g" "${CLUSTER_BUNDLE_FILE}"
-        else
-            echo "$base_image${delimeter}$tag_image not changed"
-        fi
-    fi
-done
-
-echo "Resulting bundle file images:"
-cat "${CLUSTER_BUNDLE_FILE}" | grep "image:"
-
-# FIXME: display any ENV variables once we have offline support implemented
-#grep -A1 IMAGE_URL_DEFAULT "${CLUSTER_BUNDLE_FILE}"
+USE_IMAGE_DIGESTS=true VERSION=$RELEASE_VERSION IMG=${REGISTRY}/${BASE_IMAGE}:${GITHUB_SHA} make bundle

--- a/api/v1beta1/swift_types.go
+++ b/api/v1beta1/swift_types.go
@@ -114,11 +114,11 @@ func (instance Swift) IsReady() bool {
 func SetupDefaults() {
 	// Acquire environmental defaults and initialize Swift defaults with them
 	swiftDefaults := SwiftDefaults{
-		AccountContainerImageURL:   util.GetEnvVar("SWIFT_ACCOUNT_IMAGE_URL_DEFAULT", ContainerImageAccount),
-		ContainerContainerImageURL: util.GetEnvVar("SWIFT_CONTAINER_IMAGE_URL_DEFAULT", ContainerImageContainer),
-		ObjectContainerImageURL:    util.GetEnvVar("SWIFT_OBJECT_IMAGE_URL_DEFAULT", ContainerImageObject),
-		ProxyContainerImageURL:     util.GetEnvVar("SWIFT_PROXY_IMAGE_URL_DEFAULT", ContainerImageProxy),
-		MemcachedContainerImageURL: util.GetEnvVar("SWIFT_MEMCACHED_IMAGE_URL_DEFAULT", ContainerImageMemcached),
+		AccountContainerImageURL:   util.GetEnvVar("RELATED_IMAGE_SWIFT_ACCOUNT_IMAGE_URL_DEFAULT", ContainerImageAccount),
+		ContainerContainerImageURL: util.GetEnvVar("RELATED_IMAGE_SWIFT_CONTAINER_IMAGE_URL_DEFAULT", ContainerImageContainer),
+		ObjectContainerImageURL:    util.GetEnvVar("RELATED_IMAGE_SWIFT_OBJECT_IMAGE_URL_DEFAULT", ContainerImageObject),
+		ProxyContainerImageURL:     util.GetEnvVar("RELATED_IMAGE_SWIFT_PROXY_IMAGE_URL_DEFAULT", ContainerImageProxy),
+		MemcachedContainerImageURL: util.GetEnvVar("RELATED_IMAGE_SWIFT_MEMCACHED_IMAGE_URL_DEFAULT", ContainerImageMemcached),
 	}
 
 	SetupSwiftDefaults(swiftDefaults)

--- a/config/default/manager_default_images.yaml
+++ b/config/default/manager_default_images.yaml
@@ -11,13 +11,13 @@ spec:
       containers:
       - name: manager
         env:
-        - name: SWIFT_PROXY_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_SWIFT_PROXY_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-swift-proxy-server:current-podified
-        - name: SWIFT_ACCOUNT_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_SWIFT_ACCOUNT_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-swift-account:current-podified
-        - name: SWIFT_CONTAINER_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_SWIFT_CONTAINER_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-swift-container:current-podified
-        - name: SWIFT_OBJECT_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_SWIFT_OBJECT_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-swift-object:current-podified
-        - name: SWIFT_MEMCACHED_IMAGE_URL_DEFAULT
+        - name: RELATED_IMAGE_SWIFT_MEMCACHED_IMAGE_URL_DEFAULT
           value: quay.io/podified-antelope-centos9/openstack-memcached:current-podified

--- a/config/manifests/bases/swift-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/swift-operator.clusterserviceversion.yaml
@@ -5,6 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     operatorframework.io/suggested-namespace: openstack
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/operator-type: non-standalone
   name: swift-operator.v0.0.0
   namespace: placeholder

--- a/tests/kuttl/tests/basic-deploy/01-assert-deploy-swift.yaml
+++ b/tests/kuttl/tests/basic-deploy/01-assert-deploy-swift.yaml
@@ -5,15 +5,9 @@ metadata:
 spec:
   swiftRing:
     ringReplicas: 1
-    containerImage: quay.io/podified-antelope-centos9/openstack-swift-proxy-server:current-podified
   swiftStorage:
     storageClass: local-storage
     replicas: 1
-    containerImageAccount: quay.io/podified-antelope-centos9/openstack-swift-account:current-podified
-    containerImageContainer: quay.io/podified-antelope-centos9/openstack-swift-container:current-podified
-    containerImageObject: quay.io/podified-antelope-centos9/openstack-swift-object:current-podified
-    containerImageProxy: quay.io/podified-antelope-centos9/openstack-swift-proxy-server:current-podified
-    containerImageMemcached: quay.io/podified-antelope-centos9/openstack-memcached:current-podified
   swiftProxy:
     replicas: 1
     passwordSelectors:


### PR DESCRIPTION
This PR adds support for installing the operator in disconnected network environments. To build with image-digests set USE_IMAGE_DIGESTS=true before running make bundle.

For Prow jobs we are enabling this via .prow-ci.env

This drops the old logic from create_bundle.sh which has been broken with operator-sdk's make bundle for some time.

(NOTE: this currently requires a secure registry)

Jira: [OSP-26486](https://issues.redhat.com//browse/OSP-26486)