### PR TITLE
Add role and binding to update inventory configmap

### DIFF
--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- swift_configmap_update.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.

--- a/config/rbac/swift_configmap_update.yaml
+++ b/config/rbac/swift_configmap_update.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: openstack
+  name: configmap-update
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - swift-edpm-inventory
+  verbs:
+  - update
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: configmap-update
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: configmap-update
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: openstack


### PR DESCRIPTION
A configmap update is required during the dataplane deployment.  The deployment will update the configmap with the actual disks to be used by Swift and their corresponding sizes, and the ring-rebalance pod will use this information to update the swift rings.