### PR TITLE
Run swift-recon-cron

### DIFF
--- a/pkg/swiftstorage/statefulset.go
+++ b/pkg/swiftstorage/statefulset.go
@@ -163,6 +163,14 @@ func getStorageContainers(swiftstorage *swiftv1beta1.SwiftStorage) []corev1.Cont
 			VolumeMounts:    getStorageVolumeMounts(),
 			Command:         []string{"/usr/bin/rsync", "--daemon", "--no-detach", "--config=/etc/swift/rsyncd.conf", "--log-file=/dev/stdout"},
 		},
+		{
+			Name:            "swift-recon-cron",
+			Image:           swiftstorage.Spec.ContainerImageObject,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			SecurityContext: &securityContext,
+			VolumeMounts:    getStorageVolumeMounts(),
+			Command:         []string{"sh", "-c", "while true; do /usr/bin/swift-recon-cron /etc/swift/object-server.conf -v; sleep 300; done"},
+		},
 	}
 }
 

--- a/pkg/swiftstorage/volumes.go
+++ b/pkg/swiftstorage/volumes.go
@@ -85,6 +85,12 @@ func getStorageVolumes(instance *swiftv1beta1.SwiftStorage) []corev1.Volume {
 				},
 			},
 		},
+		{
+			Name: "lock",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{Medium: ""},
+			},
+		},
 	}
 }
 
@@ -124,6 +130,11 @@ func getStorageVolumeMounts() []corev1.VolumeMount {
 			Name:      "scripts",
 			MountPath: "/usr/local/bin/container-scripts",
 			ReadOnly:  true,
+		},
+		{
+			Name:      "lock",
+			MountPath: "/var/lock",
+			ReadOnly:  false,
 		},
 	}
 }


### PR DESCRIPTION
By default this should be run periodically every 5 minutes to collect async_pending data, and most often this is run as a cronjob. However, it has to be run on every node and has to use the same pvcs as the StatefulSets, thus running it within the StatefulSet itself.