### PR TITLE
Revert "Set uid/gid in rsyncd.conf"

### DIFF
--- a/templates/swiftstorage/config/rsyncd.conf
+++ b/templates/swiftstorage/config/rsyncd.conf
@@ -5,21 +5,15 @@ max connections = 2
 path = /srv/node
 read only = false
 lock file = /tmp/account.lock
-uid = swift
-gid = swift
 
 [container]
 max connections = 4
 path = /srv/node
 read only = false
 lock file = /tmp/container.lock
-uid = swift
-gid = swift
 
 [object]
 max connections = 8
 path = /srv/node
 read only = false
 lock file = /tmp/object.lock
-uid = swift
-gid = swift


### PR DESCRIPTION
Just running as user Swift with correct permissions doesn't require this config options and simplifies overall config.

This reverts commit c1686da7156ad4cb055e84e51bf56f6101265354.