### PR TITLE
Add DNSData entries for SwiftStorage service pods

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -168,6 +168,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - network.openstack.org
+  resources:
+  - dnsdata
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - networking.k8s.io
   resources:
   - networkpolicies

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ import (
 
 	networkv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
+	infranetworkv1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
 	swiftv1beta1 "github.com/openstack-k8s-operators/swift-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/swift-operator/controllers"
 	//+kubebuilder:scaffold:imports
@@ -60,6 +61,7 @@ func init() {
 	utilruntime.Must(keystonev1beta1.AddToScheme(scheme))
 	utilruntime.Must(memcachedv1.AddToScheme(scheme))
 	utilruntime.Must(networkv1.AddToScheme(scheme))
+	utilruntime.Must(infranetworkv1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/pkg/swiftstorage/dnsdata.go
+++ b/pkg/swiftstorage/dnsdata.go
@@ -1,0 +1,56 @@
+package swiftstorage
+
+import (
+	"context"
+	"fmt"
+
+	infranetworkv1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	swiftv1 "github.com/openstack-k8s-operators/swift-operator/api/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// DNSData - Create DNS entry that openstack dnsmasq will resolve
+func DNSData(
+	ctx context.Context,
+	helper *helper.Helper,
+	hostName string,
+	ip string,
+	instance *swiftv1.SwiftStorage,
+	swiftPod corev1.Pod,
+	serviceLabels map[string]string,
+) error {
+	dnsHostCname := infranetworkv1.DNSHost{
+		IP: ip,
+		Hostnames: []string{
+			hostName,
+		},
+	}
+
+	// Create DNSData object
+	dnsData := &infranetworkv1.DNSData{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      swiftPod.Name,
+			Namespace: swiftPod.Namespace,
+			Labels:    serviceLabels,
+		},
+	}
+	dnsHosts := []infranetworkv1.DNSHost{dnsHostCname}
+
+	_, err := controllerutil.CreateOrPatch(ctx, helper.GetClient(), dnsData, func() error {
+		dnsData.Spec.Hosts = dnsHosts
+		// TODO: use value from DNSMasq instance instead of hardcode
+		dnsData.Spec.DNSDataLabelSelectorValue = "dnsdata"
+		err := controllerutil.SetControllerReference(helper.GetBeforeObject(), dnsData, helper.GetScheme())
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("Error creating DNSData %s: %w", dnsData.Name, err)
+	}
+	return nil
+}

--- a/pkg/swiftstorage/funcs.go
+++ b/pkg/swiftstorage/funcs.go
@@ -53,7 +53,7 @@ func DeviceList(ctx context.Context, h *helper.Helper, instance *swiftv1beta1.Sw
 		}
 		weight = weight / (1000 * 1000 * 1000) // 10GiB gets a weight of 10 etc.
 		// CSV: region,zone,hostname,devicename,weight
-		devices.WriteString(fmt.Sprintf("1,1,%s-%d.%s,%s,%d\n", instance.Name, replica, instance.Name, "d1", weight))
+		devices.WriteString(fmt.Sprintf("1,1,%s-%d.%s.%s.svc,%s,%d\n", instance.Name, replica, instance.Name, instance.Namespace, "d1", weight))
 	}
 	return devices.String()
 }


### PR DESCRIPTION
Storage service hostnames need to be resolvable on the dataplane nodes as well. They are used within the Swift rings to be able to allow node IP changes without updating and redistributing Swift rings.

This patch creates DNSData entries for every storage service pod, similar to [1]. It only creates DNS for the storage network, as this is the only one that should be used within the storage backend services.

There is no delete function to scale down, as we don't support scaling down for SwiftStorage instances. However, the created DNSData CRs are owned by the SwiftStorage instance, thus being deleted properly if the instance is deleted.

[1] https://github.com/openstack-k8s-operators/ovn-operator/pull/154