### PR TITLE
Bump golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,11 @@
+linters:
+  # Enable specific linter
+  # https://golangci-lint.run/usage/linters/#enabled-by-default
+  enable:
+    - errorlint
+    - revive
+    - ginkgolinter
+    - gofmt
+    - govet
+run:
+  timeout: 5m

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     - id: go-mod-tidy
 
 - repo: https://github.com/golangci/golangci-lint
-  rev: v1.52.2
+  rev: v1.55.2
   hooks:
     - id: golangci-lint
       args: ["-v"]


### PR DESCRIPTION
Bump the golangci-lint version to the newest that still supports 1.20.