### PR TITLE
Refactor ring device setup

### DIFF
--- a/controllers/swiftstorage_controller.go
+++ b/controllers/swiftstorage_controller.go
@@ -136,22 +136,6 @@ func (r *SwiftStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	serviceLabels := swiftstorage.Labels()
 	envVars := make(map[string]env.Setter)
 
-	// Check if there is already an existing ConfigMap and device list. If
-	// not, create an initial device list to bootstrap the cluster with The
-	// weights are simply set to the requested size, this will be changed
-	// once all StatefulSets are running
-	_, ctrlResult, err := configmap.GetConfigMap(ctx, helper, instance, swiftv1beta1.DeviceConfigMapName, 5*time.Second)
-	if err != nil {
-		return ctrlResult, err
-	} else if (ctrlResult != ctrl.Result{}) {
-		devices := swiftstorage.DeviceList(ctx, helper, instance)
-		tpl := swiftstorage.DeviceConfigMapTemplates(instance, devices)
-		err = configmap.EnsureConfigMaps(ctx, helper, instance, tpl, &envVars)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
-	}
-
 	// Create a ConfigMap populated with content from templates/
 	tpl := swiftstorage.ConfigMapTemplates(instance, serviceLabels, instance.Spec.MemcachedServers)
 	err = configmap.EnsureConfigMaps(ctx, helper, instance, tpl, &envVars)
@@ -164,7 +148,7 @@ func (r *SwiftStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	ctrlResult, err = svc.CreateOrPatch(ctx, helper)
+	ctrlResult, err := svc.CreateOrPatch(ctx, helper)
 	if err != nil {
 		return ctrlResult, err
 	} else if (ctrlResult != ctrl.Result{}) {
@@ -231,13 +215,6 @@ func (r *SwiftStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	instance.Status.ReadyCount = sset.GetStatefulSet().Status.ReadyReplicas
 	if instance.Status.ReadyCount == *instance.Spec.Replicas {
-		envVars := make(map[string]env.Setter)
-		devices := swiftstorage.DeviceList(ctx, helper, instance)
-		tpl = swiftstorage.DeviceConfigMapTemplates(instance, devices)
-		err = configmap.EnsureConfigMaps(ctx, helper, instance, tpl, &envVars)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
 		instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
 		instance.Status.Conditions.MarkTrue(swiftv1beta1.SwiftStorageReadyCondition, condition.ReadyMessage)
 		if err := r.Status().Update(ctx, instance); err != nil {

--- a/pkg/swiftring/funcs.go
+++ b/pkg/swiftring/funcs.go
@@ -16,9 +16,76 @@ limitations under the License.
 package swiftring
 
 import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
+
+	swiftv1beta1 "github.com/openstack-k8s-operators/swift-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/swift-operator/pkg/swift"
 )
+
+//+kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch
+
+func DeviceList(ctx context.Context, h *helper.Helper, instance *swiftv1beta1.SwiftRing) (string, string, error) {
+	// Returns a list of devices as CSV
+	devices := []string{}
+
+	listOpts := []client.ListOption{client.InNamespace(instance.GetNamespace())}
+
+	// Get all SwiftStorage instances
+	storages := &swiftv1beta1.SwiftStorageList{}
+	err := h.GetClient().List(context.Background(), storages, listOpts...)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return "", "", err
+		}
+	} else {
+		for _, storageInstance := range storages.Items {
+			for replica := 0; replica < int(*storageInstance.Spec.Replicas); replica++ {
+				cn := fmt.Sprintf("%s-%s-%d", swift.ClaimName, storageInstance.Name, replica)
+				foundClaim := &corev1.PersistentVolumeClaim{}
+				err = h.GetClient().Get(ctx, types.NamespacedName{Name: cn, Namespace: storageInstance.Namespace}, foundClaim)
+				capacity := resource.MustParse(storageInstance.Spec.StorageRequest)
+				weight, _ := capacity.AsInt64()
+				if err == nil {
+					capacity := foundClaim.Status.Capacity["storage"]
+					weight, _ = capacity.AsInt64()
+				} else {
+					h.GetLogger().Info(fmt.Sprintf("Did not find PVC %s, assuming %s as capacity", cn, storageInstance.Spec.StorageRequest))
+				}
+				weight = weight / (1000 * 1000 * 1000) // 10GiB gets a weight of 10 etc.
+				// CSV: region,zone,hostname,devicename,weight
+				devices = append(devices, fmt.Sprintf("1,1,%s-%d.%s,%s,%d\n", storageInstance.Name, replica, storageInstance.Name, "d1", weight))
+			}
+		}
+	}
+
+	// Device list must be sorted to ensure hash does not change
+	sort.Strings(devices)
+
+	var deviceList strings.Builder
+	for _, line := range devices {
+		deviceList.WriteString(line)
+	}
+
+	deviceListHash, err := util.ObjectHash(deviceList.String())
+	if err != nil {
+		return "", "", err
+	}
+
+	return deviceList.String(), deviceListHash, nil
+}
 
 func Labels() map[string]string {
 	return map[string]string{

--- a/pkg/swiftring/templates.go
+++ b/pkg/swiftring/templates.go
@@ -44,3 +44,18 @@ func ConfigMapTemplates(instance *swiftv1beta1.SwiftRing, labels map[string]stri
 		},
 	}
 }
+
+func DeviceConfigMapTemplates(instance *swiftv1beta1.SwiftRing, devices string) []util.Template {
+	data := make(map[string]string)
+	data["devices.csv"] = devices
+
+	return []util.Template{
+		{
+			Name:         swiftv1beta1.DeviceConfigMapName,
+			Namespace:    instance.Namespace,
+			Type:         util.TemplateTypeNone,
+			InstanceType: instance.Kind,
+			CustomData:   data,
+		},
+	}
+}

--- a/pkg/swiftstorage/templates.go
+++ b/pkg/swiftstorage/templates.go
@@ -45,18 +45,3 @@ func ConfigMapTemplates(instance *swiftv1beta1.SwiftStorage, labels map[string]s
 		},
 	}
 }
-
-func DeviceConfigMapTemplates(instance *swiftv1beta1.SwiftStorage, devices string) []util.Template {
-	data := make(map[string]string)
-	data["devices.csv"] = devices
-
-	return []util.Template{
-		{
-			Name:         swiftv1beta1.DeviceConfigMapName,
-			Namespace:    instance.Namespace,
-			Type:         util.TemplateTypeNone,
-			InstanceType: instance.Kind,
-			CustomData:   data,
-		},
-	}
-}


### PR DESCRIPTION
Creates device list now within the SwiftRing instance instead of the SwiftStorage instance. This is preliminary work to add device setup for dataplane nodes in the SwiftRing instance as well.

This cleans up the SwiftStorage instance quite a bit and moves ring management code into the SwiftRing instance.