### PR TITLE
Set default reader roles for Swift

### DIFF
--- a/templates/swiftproxy/config/proxy-server.conf
+++ b/templates/swiftproxy/config/proxy-server.conf
@@ -66,6 +66,8 @@ use = egg:swift#keystoneauth
 operator_roles = admin, SwiftOperator
 cache = swift.cache
 reseller_prefix=AUTH_
+system_reader_roles = SwiftSystemReader
+project_reader_roles = SwiftProjectReader
 
 [filter:authtoken]
 paste.filter_factory = keystonemiddleware.auth_token:filter_factory


### PR DESCRIPTION
Sets the default reader roles to SwiftSystemReader and SwiftProjectReader, which align with the defaults from former TripleO deployments. Customizing these needs to be done by overriding config files using DefaultConfigOverwrite.