### PR TITLE
Add default dispersion.conf

### DIFF
--- a/templates/swiftproxy/config/dispersion.conf
+++ b/templates/swiftproxy/config/dispersion.conf
@@ -1,0 +1,9 @@
+[dispersion]
+auth_url = {{ .KeystoneInternalURL }}
+auth_user = {{ .ServiceUser }}
+auth_key = {{ .ServicePassword }}
+auth_version = 3.0
+project_name = service
+project_domain_name = default
+user_domain_name = default
+dispersion_coverage = 100.0


### PR DESCRIPTION
This allows running the tools swift-dispersion-populate and swift-dispersion-report manually if needed.