### PR TITLE
Enable S3 and staticweb proxy middlewares

### DIFF
--- a/templates/swiftproxy/config/00-proxy-server.conf
+++ b/templates/swiftproxy/config/00-proxy-server.conf
@@ -3,7 +3,7 @@ bind_host = 127.0.0.1
 bind_port = 8081
 
 [pipeline:main]
-pipeline = catch_errors gatekeeper healthcheck proxy-logging cache listing_formats container_sync bulk tempurl ratelimit authtoken keystone copy container-quotas account-quotas slo dlo versioned_writes proxy-logging proxy-server
+pipeline = catch_errors gatekeeper healthcheck proxy-logging cache listing_formats container_sync bulk tempurl ratelimit formpost authtoken s3api s3token keystone staticweb copy container-quotas account-quotas slo dlo versioned_writes proxy-logging proxy-server
 
 [app:proxy-server]
 use = egg:swift#proxy
@@ -72,7 +72,7 @@ project_reader_roles = SwiftProjectReader
 [filter:authtoken]
 paste.filter_factory = keystonemiddleware.auth_token:filter_factory
 www_authenticate_uri = {{ .KeystonePublicURL }}
-auth_url = {{ .KeystoneInternalURL }}
+auth_url = {{ .KeystonePublicURL }}
 auth_plugin=password
 project_domain_id = default
 user_domain_id = default
@@ -80,3 +80,13 @@ project_name = service
 username = {{ .ServiceUser }}
 password = {{ .ServicePassword }}
 delay_auth_decision = True
+
+[filter:s3api]
+use = egg:swift#s3api
+
+[filter:s3token]
+use = egg:swift#s3token
+auth_uri = {{ .KeystonePublicURL }}/v3
+
+[filter:staticweb]
+use = egg:swift#staticweb


### PR DESCRIPTION
This ensures feature parity with older TripleO deployments. Also change the used Keystone endpoint to public to ensure SSL is used if enabled.