### PR TITLE
Add finalizer for SwiftRing and ConfigMap

### DIFF
--- a/templates/swiftring/bin/swift-ring-rebalance.sh
+++ b/templates/swiftring/bin/swift-ring-rebalance.sh
@@ -87,6 +87,7 @@ CONFIGMAP_JSON='{
     "metadata":{
         "name":"'${CM_NAME}'",
         "namespace":"'${NAMESPACE}'",
+        "finalizers": ["swift-ring/finalizer"],
         "ownerReferences": [
             {
                 "apiVersion": "'${OWNER_APIVERSION}'",


### PR DESCRIPTION
Deletion of the Swift Ring ConfigMap should be prevented as far as possible. The .builder files contain data placements, which is not recoverable if lost. Thus prevent deletion except if the instance itself got deleted by using a finalizer.