### PR TITLE
Set pod affinity to spread services across OCP workers

### DIFF
--- a/pkg/swift/funcs.go
+++ b/pkg/swift/funcs.go
@@ -16,6 +16,9 @@ limitations under the License.
 package swift
 
 import (
+	common "github.com/openstack-k8s-operators/lib-common/modules/common"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/affinity"
+
 	corev1 "k8s.io/api/core/v1"
 	"math/rand"
 )
@@ -49,4 +52,18 @@ func RandomString(length int) string {
 		str[i] = sample[rand.Intn(len(sample))]
 	}
 	return string(str)
+}
+
+// GetPodAffinity - Returns a corev1.Affinity reference for the specified component.
+func GetPodAffinity(componentName string) *corev1.Affinity {
+	// If possible two pods of the same component (e.g cinder-api) should not
+	// run on the same worker node. If this is not possible they get still
+	// created on the same worker node.
+	return affinity.DistributePods(
+		common.ComponentSelector,
+		[]string{
+			componentName,
+		},
+		corev1.LabelHostname,
+	)
 }

--- a/pkg/swiftproxy/deployment.go
+++ b/pkg/swiftproxy/deployment.go
@@ -134,7 +134,8 @@ func Deployment(
 						// as root/swift/0440.
 						FSGroup: ptr.To(swift.RunAsUser),
 					},
-					Volumes: volumes,
+					Volumes:  volumes,
+					Affinity: swift.GetPodAffinity(ComponentName),
 					Containers: []corev1.Container{
 						{
 							Name:            "ring-sync",

--- a/pkg/swiftstorage/statefulset.go
+++ b/pkg/swiftstorage/statefulset.go
@@ -227,6 +227,7 @@ func StatefulSet(
 					},
 					Volumes:    getStorageVolumes(swiftstorage),
 					Containers: getStorageContainers(swiftstorage),
+					Affinity:   swift.GetPodAffinity(ComponentName),
 				},
 			},
 			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{{


### PR DESCRIPTION
The storage and proxy services should be spread across all OCP workers if possible.