### PR TITLE
Avoid second rebalance on startup

### DIFF
--- a/controllers/swiftring_controller.go
+++ b/controllers/swiftring_controller.go
@@ -160,6 +160,12 @@ func (r *SwiftRingReconciler) reconcileNormal(ctx context.Context, instance *swi
 
 	deviceList, deviceListHash, err := swiftring.DeviceList(ctx, helper, instance)
 	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			swiftv1beta1.SwiftRingReadyCondition,
+			condition.ErrorReason,
+			condition.SeverityWarning,
+			swiftv1beta1.SwiftRingReadyErrorMessage,
+			err.Error()))
 		return ctrl.Result{}, err
 	}
 

--- a/templates/swiftring/bin/swift-ring-tool
+++ b/templates/swiftring/bin/swift-ring-tool
@@ -61,12 +61,6 @@ function update() {
         # Check if host/disk exists and only add if not
         swift-ring-builder object.builder search --ip $HOST --device $DEVICE_NAME
         [ $? -eq 2 ] && swift-ring-builder object.builder add --region $REGION --zone $ZONE --ip $HOST --port 6200 --device $DEVICE_NAME --weight $WEIGHT
-
-        # This will change the weights, eg. after bootstrapping and correct PVC
-        # sizes are known.
-        swift-ring-builder account.builder set_weight --region $REGION --zone $ZONE --ip $HOST --port 6202 --device $DEVICE_NAME $WEIGHT
-        swift-ring-builder container.builder set_weight --region $REGION --zone $ZONE --ip $HOST --port 6201 --device $DEVICE_NAME $WEIGHT
-        swift-ring-builder object.builder set_weight --region $REGION --zone $ZONE --ip $HOST --port 6200 --device $DEVICE_NAME $WEIGHT
 done < $DEVICESFILE
 }
 


### PR DESCRIPTION
Until now the SwiftRing instance created a ring with estimated disk sizes if PVCs and size data was not yet available. Rings were updated later once sizes were known.

However, this is no longer needed. PVCs have to be created eventually if SwiftStorage replicas > 0, thus we can requeue until these are bound. This eliminates a second rebalance with the correct values shortly after.

It also simplifies the rebalance script and removes a possible risk when changing weights for existing devices. Initially set weights are kept now, which should be the correct ones from the beginning.