### PR TITLE
Fix dataplane devices in rings

### DIFF
--- a/pkg/swiftring/funcs.go
+++ b/pkg/swiftring/funcs.go
@@ -71,7 +71,7 @@ func DeviceList(ctx context.Context, h *helper.Helper, instance *swiftv1beta1.Sw
 			}
 			weight = weight / (1000 * 1000 * 1000) // 10GiB gets a weight of 10 etc.
 			// Format: region zone hostname devicename weight
-			devices = append(devices, fmt.Sprintf("1 1 %s-%d.%s %s %d\n", storageInstance.Name, replica, storageInstance.Name, "d1", weight))
+			devices = append(devices, fmt.Sprintf("1 1 %s-%d.%s.%s.svc %s %d\n", storageInstance.Name, replica, storageInstance.Name, storageInstance.Namespace, "d1", weight))
 		}
 	}
 


### PR DESCRIPTION
If edpm_swift_disks is set in a nodeset both globally and per-node, only the per-node setting is used.