### PR TITLE
Log cleanup with necessary changes to do so

### DIFF
--- a/controllers/swift_controller.go
+++ b/controllers/swift_controller.go
@@ -238,8 +238,9 @@ func (r *SwiftReconciler) reconcileNormal(ctx context.Context, instance *swiftv1
 				condition.RequestedReason,
 				condition.SeverityInfo,
 				condition.MemcachedReadyWaitingMessage))
-			r.Log.Error(err, "memcached not found")
+			r.Log.Info(fmt.Sprintf("%s... requeueing", condition.MemcachedReadyWaitingMessage))
 			return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
+
 		}
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			condition.MemcachedReadyCondition,
@@ -256,7 +257,7 @@ func (r *SwiftReconciler) reconcileNormal(ctx context.Context, instance *swiftv1
 			condition.RequestedReason,
 			condition.SeverityInfo,
 			condition.MemcachedReadyWaitingMessage))
-		r.Log.Error(err, "memcached is not ready")
+		r.Log.Info(fmt.Sprintf("%s... requeueing", condition.MemcachedReadyWaitingMessage))
 		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
 	}
 	// Mark the Memcached Service as Ready if we get to this point with no errors

--- a/controllers/swiftproxy_controller.go
+++ b/controllers/swiftproxy_controller.go
@@ -556,28 +556,29 @@ func (r *SwiftProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	instance.Status.ReadyCount = depl.GetDeployment().Status.ReadyReplicas
 
-	// verify if network attachment matches expectations
-	networkReady, networkAttachmentStatus, err := nad.VerifyNetworkStatusFromAnnotation(ctx, helper, instance.Spec.NetworkAttachments, serviceLabels, instance.Status.ReadyCount)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
+	if instance.Status.ReadyCount == *instance.Spec.Replicas {
 
-	instance.Status.NetworkAttachments = networkAttachmentStatus
-	if networkReady {
-		instance.Status.Conditions.MarkTrue(condition.NetworkAttachmentsReadyCondition, condition.NetworkAttachmentsReadyMessage)
-	} else {
-		err := fmt.Errorf("not all pods have interfaces with ips as configured in NetworkAttachments: %s", instance.Spec.NetworkAttachments)
-		instance.Status.Conditions.Set(condition.FalseCondition(
-			condition.NetworkAttachmentsReadyCondition,
-			condition.ErrorReason,
-			condition.SeverityWarning,
-			condition.NetworkAttachmentsReadyErrorMessage,
-			err.Error()))
+		// verify if network attachment matches expectations
+		networkReady, networkAttachmentStatus, err := nad.VerifyNetworkStatusFromAnnotation(ctx, helper, instance.Spec.NetworkAttachments, serviceLabels, instance.Status.ReadyCount)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
 
-		return ctrl.Result{}, err
-	}
+		instance.Status.NetworkAttachments = networkAttachmentStatus
+		if networkReady {
+			instance.Status.Conditions.MarkTrue(condition.NetworkAttachmentsReadyCondition, condition.NetworkAttachmentsReadyMessage)
+		} else {
+			err := fmt.Errorf("not all pods have interfaces with ips as configured in NetworkAttachments: %s", instance.Spec.NetworkAttachments)
+			instance.Status.Conditions.Set(condition.FalseCondition(
+				condition.NetworkAttachmentsReadyCondition,
+				condition.ErrorReason,
+				condition.SeverityWarning,
+				condition.NetworkAttachmentsReadyErrorMessage,
+				err.Error()))
 
-	if instance.Status.ReadyCount > 0 {
+			return ctrl.Result{}, err
+		}
+
 		instance.Status.Conditions.MarkTrue(swiftv1beta1.SwiftProxyReadyCondition, condition.ReadyMessage)
 	} else {
 		instance.Status.Conditions.Set(condition.FalseCondition(

--- a/controllers/swiftproxy_controller.go
+++ b/controllers/swiftproxy_controller.go
@@ -386,6 +386,10 @@ func (r *SwiftProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	if !keystoneAPI.IsReady() {
+		r.Log.Info("Keystone API is not yet ready... requeueing")
+		return ctrl.Result{RequeueAfter: time.Duration(10) * time.Second}, nil
+	}
 	keystonePublicURL, err := keystoneAPI.GetEndpoint(endpoint.EndpointPublic)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/controllers/swiftring_controller.go
+++ b/controllers/swiftring_controller.go
@@ -166,6 +166,10 @@ func (r *SwiftRingReconciler) reconcileNormal(ctx context.Context, instance *swi
 			condition.SeverityWarning,
 			swiftv1beta1.SwiftRingReadyErrorMessage,
 			err.Error()))
+		if apierrors.IsNotFound(err) {
+			r.Log.Info(fmt.Sprintf("%s... requeueing", err.Error()))
+			return ctrl.Result{RequeueAfter: time.Duration(5) * time.Second}, nil
+		}
 		return ctrl.Result{}, err
 	}
 

--- a/templates/common/ring-sync.sh
+++ b/templates/common/ring-sync.sh
@@ -2,22 +2,35 @@
 TARFILE="/var/lib/config-data/rings/swiftrings.tar.gz"
 MTIME="0"
 
-# This is done only initially, will be done by Kolla eventually
-mkdir /etc/swift/account-server.conf.d /etc/swift/container-server.conf.d /etc/swift/object-server.conf.d /etc/swift/object-expirer.conf.d /etc/swift/proxy-server.conf.d
+for f in /var/lib/config-data/swiftconf/swift.conf \
+    /var/lib/config-data/default/internal-client.conf \
+    /var/lib/config-data/default/rsyncd.conf \
+    /var/lib/config-data/default/dispersion.conf \
+    /var/lib/config-data/default/keymaster.conf; do
+    [ -e $f ] && cp -t /etc/swift/ $f
+done
 
-cp -t /etc/swift/ /var/lib/config-data/swiftconf/swift.conf /var/lib/config-data/default/internal-client.conf /var/lib/config-data/default/rsyncd.conf /var/lib/config-data/default/dispersion.conf /var/lib/config-data/default/keymaster.conf
+for s in account-server \
+    container-server \
+    object-server \
+    object-expirer \
+    proxy-server; do
+    if [ -e /var/lib/config-data/default/*${s}*.conf ]; then
+        [ ! -d  /etc/swift/${s}.conf.d ] && mkdir /etc/swift/${s}.conf.d
+        cp -t /etc/swift/${s}.conf.d/ /var/lib/config-data/default/*${s}*.conf
+    fi
+done
 
-cp -t /etc/swift/account-server.conf.d/ /var/lib/config-data/default/*account-server*.conf
-cp -t /etc/swift/container-server.conf.d/ /var/lib/config-data/default/*container-server*.conf
-cp -t /etc/swift/object-server.conf.d/ /var/lib/config-data/default/*object-server*.conf
-cp -t /etc/swift/object-expirer.conf.d/ /var/lib/config-data/default/*object-expirer*.conf
-cp -t /etc/swift/proxy-server.conf.d/ /var/lib/config-data/default/*proxy-server*.conf
-
+# This loop checks every 60 seconds if the ring files from the configmap got
+# updated and if so, extracts them /etc/swift. Swift services notice the change
+# and reload the ring files, thus no pod restart required
 while true; do
     if [ -e $TARFILE ] ; then
         _MTIME=$(stat -L --printf "%Y" $TARFILE)
         if [ $MTIME != $_MTIME ]; then
-            tar -xvzf $TARFILE -C etc/swift/
+            tar -xzf $TARFILE -C etc/swift/
+            find /etc/swift/ -type f -ls
+            echo
         fi
         MTIME=$_MTIME
     fi


### PR DESCRIPTION
Quite a few logging messages should not raise an error, but simply inform an user about the current state and requeue accordingly. This also avoids exponential backoffs with large requeue times due to raising the same error very quickly again. 

While doing this, improving/adding checks to requeue if dependencies are not yet ready, avoiding stacktrace logs. Cleaning this up makes users more aware of actual errors that should be investigated.