### PR TITLE
Fix missing swiftoperator role

### DIFF
--- a/controllers/swiftproxy_controller.go
+++ b/controllers/swiftproxy_controller.go
@@ -395,8 +395,12 @@ func (r *SwiftProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
-	// Create OpenStack roles for Swift RBAC
+	// Create common and RBAC OpenStack roles
 	os, _, err := keystonev1.GetAdminServiceClient(ctx, helper, keystoneAPI)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	_, err = os.CreateRole(r.Log, "swiftoperator")
 	if err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
The swiftoperator role is created in TripleO-deployments, thus it should be created by the swift-operator as well.

Jira: OSPRH-5568