### PR TITLE
Fix swift proxy config regression

### DIFF
--- a/templates/swiftproxy/config/00-proxy-server.conf
+++ b/templates/swiftproxy/config/00-proxy-server.conf
@@ -3,7 +3,7 @@ bind_ip = {{ .BindIP }}
 bind_port = 8081
 
 [pipeline:main]
-pipeline = catch_errors gatekeeper healthcheck proxy-logging cache listing_formats container_sync bulk tempurl ratelimit formpost authtoken s3api s3token keystone staticweb copy container-quotas account-quotas slo dlo versioned_writes {{ if .SecretRef }} kms_keymaster encryption {{end}} proxy-logging proxy-server
+pipeline = catch_errors gatekeeper healthcheck proxy-logging cache listing_formats bulk tempurl ratelimit formpost authtoken s3api s3token keystone staticweb copy container-quotas account-quotas slo dlo versioned_writes symlink {{ if .SecretRef }} kms_keymaster encryption {{end}} proxy-logging proxy-server
 
 [app:proxy-server]
 use = egg:swift#proxy
@@ -49,11 +49,12 @@ use = egg:swift#account_quotas
 [filter:gatekeeper]
 use = egg:swift#gatekeeper
 
-[filter:container_sync]
-use = egg:swift#container_sync
+[filter:symlink]
+use = egg:swift#symlink
 
 [filter:versioned_writes]
 use = egg:swift#versioned_writes
+allow_versioned_writes = true
 
 [filter:listing_formats]
 use = egg:swift#listing_formats


### PR DESCRIPTION
The versioned_writes middleware was missing a setting to be enabled and exposed to the /info endpoint, and it also requires the symlink middleware to be enabled.

container_sync is not enabled in TripleO-deployments, let's keep the default unchanged and remove it.