### PR TITLE
Store .ring.gz files as separate keys in ConfigMap

### DIFF
--- a/templates/common/ring-sync.sh
+++ b/templates/common/ring-sync.sh
@@ -28,7 +28,7 @@ while true; do
     if [ -e $TARFILE ] ; then
         _MTIME=$(stat -L --printf "%Y" $TARFILE)
         if [ $MTIME != $_MTIME ]; then
-            tar -xzf $TARFILE -C etc/swift/
+            cp /var/lib/config-data/rings/*.ring.gz /etc/swift/.
             find /etc/swift/ -type f -ls
             echo
         fi

--- a/templates/swiftring/bin/swift-ring-tool
+++ b/templates/swiftring/bin/swift-ring-tool
@@ -27,6 +27,9 @@ function get() {
             # Get JSON keyvalue without jq
             grep -e '"swiftrings.tar.gz": ".*"' "${CM_NAME}.json"  | cut -f 4 -d '"' | base64 -d > $TARFILE
             [ -e $TARFILE ] && tar --totals -xzf $TARFILE
+            grep -e '"account.ring.gz": ".*"' "${CM_NAME}.json"  | cut -f 4 -d '"' | base64 -d > account.ring.gz
+            grep -e '"container.ring.gz": ".*"' "${CM_NAME}.json"  | cut -f 4 -d '"' | base64 -d > container.ring.gz
+            grep -e '"object.ring.gz": ".*"' "${CM_NAME}.json"  | cut -f 4 -d '"' | base64 -d > object.ring.gz
         ;;
 
         "404")
@@ -98,6 +101,9 @@ function remove() {
 function push() {
     # Tar up all the ring data and either create or update the SwiftRing ConfigMap
     BINARY_DATA=`tar --totals -cz *.builder *.ring.gz backups/*.builder | /usr/bin/base64 -w 0`
+    ACCOUNT_RING_GZ=`base64 -w 0 account.ring.gz`
+    CONTAINER_RING_GZ=`base64 -w 0 container.ring.gz`
+    OBJECT_RING_GZ=`base64 -w 0 object.ring.gz`
 
     if [ ! -e "${CM_NAME}.json" ]; then
         METHOD="POST"
@@ -127,6 +133,9 @@ function push() {
         },
         "binaryData":{
             "swiftrings.tar.gz": "'${BINARY_DATA}'",
+            "account.ring.gz": "'${ACCOUNT_RING_GZ}'",
+            "container.ring.gz": "'${CONTAINER_RING_GZ}'",
+            "object.ring.gz": "'${OBJECT_RING_GZ}'"
         }
     }'
 

--- a/templates/swiftring/bin/swift-ring-tool
+++ b/templates/swiftring/bin/swift-ring-tool
@@ -155,11 +155,12 @@ function usage() {
     echo "get        Fetch rings from ConfigMap ${CM_NAME}"
     echo "init       Create new .builder files if not existing"
     echo "update     Update rings using input from ${DEVICESFILE}"
-    echo "drain      Set weight of all node devices to 0"
-    echo "remove     Remove node from all rings"
     echo "rebalance  Rebalance rings"
     echo "push       Push rings to ConfigMap ${CM_NAME}"
     echo "all        All above operations in sequence"
+    echo
+    echo "drain      Set weight of all node devices to 0"
+    echo "remove     Remove node from all rings"
     echo
 }
 

--- a/templates/swiftring/bin/swift-ring-tool
+++ b/templates/swiftring/bin/swift-ring-tool
@@ -102,31 +102,33 @@ function push() {
     if [ ! -e "${CM_NAME}.json" ]; then
         METHOD="POST"
         URL="${BASE_URL}"
-
-        CONFIGMAP_JSON='{
-            "apiVersion":"v1",
-            "kind":"ConfigMap",
-            "metadata":{
-                "name":"'${CM_NAME}'",
-                "namespace":"'${NAMESPACE}'",
-                "finalizers": ["swift-ring/finalizer"],
-                "ownerReferences": [
-                    {
-                        "apiVersion": "'${OWNER_APIVERSION}'",
-                        "kind": "'${OWNER_KIND}'",
-                        "name": "'${OWNER_NAME}'",
-                        "uid": "'${OWNER_UID}'"
-                    }
-                ]
-            },
-            "binaryData":{
-                "swiftrings.tar.gz": "'${BINARY_DATA}'"
-            }
-        }'
+        VERSION=""
     else
         METHOD="PUT"
-        CONFIGMAP_JSON=$(cat "${CM_NAME}.json" | sed -e 's#\"swiftrings.tar.gz\": \".*\"#\"swiftrings.tar.gz\": \"'${BINARY_DATA}'\"#g')
+        VERSION="$(grep -oP '"resourceVersion": ".*"' "${CM_NAME}.json"),"
     fi
+
+    CONFIGMAP_JSON='{
+        "apiVersion":"v1",
+        "kind":"ConfigMap",
+        "metadata":{
+            '${VERSION}'
+            "name":"'${CM_NAME}'",
+            "namespace":"'${NAMESPACE}'",
+            "finalizers": ["swift-ring/finalizer"],
+            "ownerReferences": [
+                {
+                    "apiVersion": "'${OWNER_APIVERSION}'",
+                    "kind": "'${OWNER_KIND}'",
+                    "name": "'${OWNER_NAME}'",
+                    "uid": "'${OWNER_UID}'"
+                }
+            ]
+        },
+        "binaryData":{
+            "swiftrings.tar.gz": "'${BINARY_DATA}'",
+        }
+    }'
 
     # https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/config-map-v1/#update-replace-the-specified-configmap
     /usr/bin/curl \


### PR DESCRIPTION
This will make it possible to use projectedVolumes and remove the need for the ring-sync script and container afterwards. 

Also fixing a minor issue with the help text alongside.

Proposing this PR now to make sure the separate keys are available and preventing handling of legacy configmaps later on.