### PR TITLE
Do not use MustParse to process PVC size

### DIFF
--- a/controllers/swiftstorage_controller.go
+++ b/controllers/swiftstorage_controller.go
@@ -255,7 +255,16 @@ func (r *SwiftStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Statefulset with all backend containers
-	sset := statefulset.NewStatefulSet(swiftstorage.StatefulSet(instance, serviceLabels, serviceAnnotations, inputHash), 5*time.Second)
+	sspec, err := swiftstorage.StatefulSet(instance, serviceLabels, serviceAnnotations, inputHash)
+	if err != nil {
+		instance.Status.Conditions.Set(condition.FalseCondition(
+			swiftv1beta1.SwiftStorageReadyCondition,
+			condition.RequestedReason,
+			condition.SeverityInfo,
+			condition.DeploymentReadyRunningMessage))
+		return ctrl.Result{}, err
+	}
+	sset := statefulset.NewStatefulSet(sspec, 5*time.Second)
 	ctrlResult, err = sset.CreateOrPatch(ctx, helper)
 	if err != nil {
 		return ctrlResult, err


### PR DESCRIPTION
The `resource.MustParse` function was previously used by the operator to process the `storageSize` request provided by the top-level `Swift` `CR`. However, if the human operator passes a wrong `StorageRequest` size, a `panic()` is generated without any chance to recover. This happens because the `MustParse` implementation wraps the `ParseQuantity` function, but it returns `panic()` instead of propagating the error that can be easily caught at the operator level. This change moves away from the `MustParse` usage and rely on the `ParseQuantity` mechanism, providing an error that can be handled by the swift-operator.