### PR TITLE
Configure Ceilometer middleware

### DIFF
--- a/api/bases/swift.openstack.org_swiftproxies.yaml
+++ b/api/bases/swift.openstack.org_swiftproxies.yaml
@@ -48,6 +48,11 @@ spec:
           spec:
             description: SwiftProxySpec defines the desired state of SwiftProxy
             properties:
+              ceilometerEnabled:
+                default: false
+                description: Enables ceilometer in the swift proxy and creates required
+                  resources
+                type: boolean
               containerImageProxy:
                 description: Swift Proxy Container Image URL
                 type: string
@@ -257,6 +262,11 @@ spec:
                       from the Secret
                     type: string
                 type: object
+              rabbitMqClusterName:
+                default: rabbitmq
+                description: RabbitMQ instance name to request a transportURL for
+                  Ceilometer middleware
+                type: string
               replicas:
                 default: 1
                 description: Replicas of Swift Proxy
@@ -306,6 +316,7 @@ spec:
             required:
             - containerImageProxy
             - memcachedServers
+            - rabbitMqClusterName
             - replicas
             - secret
             - serviceUser
@@ -372,6 +383,9 @@ spec:
                 description: ReadyCount of SwiftProxy instances
                 format: int32
                 type: integer
+              transportURLSecret:
+                description: TransportURLSecret - Secret containing RabbitMQ transportURL
+                type: string
             type: object
         type: object
     served: true

--- a/api/bases/swift.openstack.org_swifts.yaml
+++ b/api/bases/swift.openstack.org_swifts.yaml
@@ -67,6 +67,11 @@ spec:
                 description: SwiftProxy - Spec definition for the Proxy service of
                   this Swift deployment
                 properties:
+                  ceilometerEnabled:
+                    default: false
+                    description: Enables ceilometer in the swift proxy and creates
+                      required resources
+                    type: boolean
                   containerImageProxy:
                     description: Swift Proxy Container Image URL
                     type: string
@@ -284,6 +289,11 @@ spec:
                           from the Secret
                         type: string
                     type: object
+                  rabbitMqClusterName:
+                    default: rabbitmq
+                    description: RabbitMQ instance name to request a transportURL
+                      for Ceilometer middleware
+                    type: string
                   replicas:
                     default: 1
                     description: Replicas of Swift Proxy
@@ -333,6 +343,7 @@ spec:
                 required:
                 - containerImageProxy
                 - memcachedServers
+                - rabbitMqClusterName
                 - replicas
                 - secret
                 - serviceUser

--- a/api/v1beta1/swiftproxy_types.go
+++ b/api/v1beta1/swiftproxy_types.go
@@ -78,6 +78,11 @@ type SwiftProxySpecCore struct {
 	// List of memcached servers.
 	MemcachedServers string `json:"memcachedServers"`
 
+	// +kubebuilder:validation:Required
+	// +kubebuilder:default=rabbitmq
+	// RabbitMQ instance name to request a transportURL for Ceilometer middleware
+	RabbitMqClusterName string `json:"rabbitMqClusterName"`
+
 	// +kubebuilder:validation:Optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// TLS - Parameters related to the TLS
@@ -91,6 +96,11 @@ type SwiftProxySpecCore struct {
 	// +kubebuilder:default=false
 	// Encrypts new objects at rest
 	EncryptionEnabled bool `json:"encryptionEnabled"`
+
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:default=false
+	// Enables ceilometer in the swift proxy and creates required resources
+	CeilometerEnabled bool `json:"ceilometerEnabled"`
 }
 
 // ProxyOverrideSpec to override the generated manifest of several child resources.
@@ -113,6 +123,9 @@ type SwiftProxyStatus struct {
 
 	// Map of hashes to track e.g. job status
 	Hash map[string]string `json:"hash,omitempty"`
+
+	// TransportURLSecret - Secret containing RabbitMQ transportURL
+	TransportURLSecret string `json:"transportURLSecret,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/swift.openstack.org_swiftproxies.yaml
+++ b/config/crd/bases/swift.openstack.org_swiftproxies.yaml
@@ -48,6 +48,11 @@ spec:
           spec:
             description: SwiftProxySpec defines the desired state of SwiftProxy
             properties:
+              ceilometerEnabled:
+                default: false
+                description: Enables ceilometer in the swift proxy and creates required
+                  resources
+                type: boolean
               containerImageProxy:
                 description: Swift Proxy Container Image URL
                 type: string
@@ -257,6 +262,11 @@ spec:
                       from the Secret
                     type: string
                 type: object
+              rabbitMqClusterName:
+                default: rabbitmq
+                description: RabbitMQ instance name to request a transportURL for
+                  Ceilometer middleware
+                type: string
               replicas:
                 default: 1
                 description: Replicas of Swift Proxy
@@ -306,6 +316,7 @@ spec:
             required:
             - containerImageProxy
             - memcachedServers
+            - rabbitMqClusterName
             - replicas
             - secret
             - serviceUser
@@ -372,6 +383,9 @@ spec:
                 description: ReadyCount of SwiftProxy instances
                 format: int32
                 type: integer
+              transportURLSecret:
+                description: TransportURLSecret - Secret containing RabbitMQ transportURL
+                type: string
             type: object
         type: object
     served: true

--- a/config/crd/bases/swift.openstack.org_swifts.yaml
+++ b/config/crd/bases/swift.openstack.org_swifts.yaml
@@ -67,6 +67,11 @@ spec:
                 description: SwiftProxy - Spec definition for the Proxy service of
                   this Swift deployment
                 properties:
+                  ceilometerEnabled:
+                    default: false
+                    description: Enables ceilometer in the swift proxy and creates
+                      required resources
+                    type: boolean
                   containerImageProxy:
                     description: Swift Proxy Container Image URL
                     type: string
@@ -284,6 +289,11 @@ spec:
                           from the Secret
                         type: string
                     type: object
+                  rabbitMqClusterName:
+                    default: rabbitmq
+                    description: RabbitMQ instance name to request a transportURL
+                      for Ceilometer middleware
+                    type: string
                   replicas:
                     default: 1
                     description: Replicas of Swift Proxy
@@ -333,6 +343,7 @@ spec:
                 required:
                 - containerImageProxy
                 - memcachedServers
+                - rabbitMqClusterName
                 - replicas
                 - secret
                 - serviceUser

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -215,6 +215,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - rabbitmq.openstack.org
+  resources:
+  - transporturls
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings

--- a/controllers/swift_controller.go
+++ b/controllers/swift_controller.go
@@ -452,6 +452,8 @@ func (r *SwiftReconciler) proxyCreateOrUpdate(ctx context.Context, instance *swi
 			TLS:                    instance.Spec.SwiftProxy.TLS,
 			DefaultConfigOverwrite: instance.Spec.SwiftProxy.DefaultConfigOverwrite,
 			EncryptionEnabled:      instance.Spec.SwiftProxy.EncryptionEnabled,
+			RabbitMqClusterName:    instance.Spec.SwiftProxy.RabbitMqClusterName,
+			CeilometerEnabled:      instance.Spec.SwiftProxy.CeilometerEnabled,
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ import (
 	dataplanev1 "github.com/openstack-k8s-operators/dataplane-operator/api/v1beta1"
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	infranetworkv1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
+	rabbitmqv1 "github.com/openstack-k8s-operators/infra-operator/apis/rabbitmq/v1beta1"
 	swiftv1beta1 "github.com/openstack-k8s-operators/swift-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/swift-operator/controllers"
 	//+kubebuilder:scaffold:imports
@@ -66,6 +67,7 @@ func init() {
 	utilruntime.Must(infranetworkv1.AddToScheme(scheme))
 	utilruntime.Must(dataplanev1.AddToScheme(scheme))
 	utilruntime.Must(barbicanv1.AddToScheme(scheme))
+	utilruntime.Must(rabbitmqv1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 

--- a/pkg/swiftproxy/templates.go
+++ b/pkg/swiftproxy/templates.go
@@ -35,6 +35,8 @@ func SecretTemplates(
 	memcachedServers string,
 	bindIP string,
 	secretRef string,
+	keystoneRegion string,
+	transportURL string,
 ) []util.Template {
 	templateParameters := make(map[string]interface{})
 	templateParameters["ServiceUser"] = instance.Spec.ServiceUser
@@ -44,6 +46,8 @@ func SecretTemplates(
 	templateParameters["MemcachedServers"] = memcachedServers
 	templateParameters["BindIP"] = bindIP
 	templateParameters["SecretRef"] = secretRef
+	templateParameters["KeystoneRegion"] = keystoneRegion
+	templateParameters["TransportURL"] = transportURL
 
 	// create httpd  vhost template parameters
 	httpdVhostConfig := map[string]interface{}{}

--- a/templates/swiftproxy/config/00-proxy-server.conf
+++ b/templates/swiftproxy/config/00-proxy-server.conf
@@ -3,7 +3,7 @@ bind_ip = {{ .BindIP }}
 bind_port = 8081
 
 [pipeline:main]
-pipeline = catch_errors gatekeeper healthcheck proxy-logging cache listing_formats bulk tempurl ratelimit formpost authtoken s3api s3token keystone staticweb copy container-quotas account-quotas slo dlo versioned_writes symlink {{ if .SecretRef }} kms_keymaster encryption {{end}} proxy-logging proxy-server
+pipeline = catch_errors gatekeeper healthcheck proxy-logging cache listing_formats bulk tempurl ratelimit formpost authtoken s3api s3token keystone staticweb copy container-quotas account-quotas slo dlo versioned_writes symlink {{ if .SecretRef }} kms_keymaster encryption {{end}} {{ if .TransportURL }} ceilometer {{end}} proxy-logging proxy-server
 
 [app:proxy-server]
 use = egg:swift#proxy
@@ -98,3 +98,13 @@ keymaster_config_path = /etc/swift/keymaster.conf
 
 [filter:encryption]
 use = egg:swift#encryption
+
+[filter:ceilometer]
+paste.filter_factory = ceilometermiddleware.swift:filter_factory
+auth_url = {{ .KeystonePublicURL }}
+password = {{ .ServicePassword }}
+username = {{ .ServiceUser }}
+region_name  = {{ .KeystoneRegion }}
+url = {{ .TransportURL }}
+project_name = service
+nonblocking_notify = True


### PR DESCRIPTION
The Ceilometer middleware sends notifications using RabbitMQ, thus creating a user and secret to configure the middleware.