### PR TITLE
Fix httpd proxy configuration for s3api

### DIFF
--- a/templates/swiftproxy/config/httpd.conf
+++ b/templates/swiftproxy/config/httpd.conf
@@ -41,7 +41,7 @@ CustomLog /dev/stdout proxy env=forwarded
 
   ## Proxy rules
   ProxyRequests Off
-  ProxyPreserveHost Off
+  ProxyPreserveHost On
   ProxyPass / http://localhost:8081/ retry=10
   ProxyPassReverse / http://localhost:8081/
 


### PR DESCRIPTION
Enable ProxyPreserveHost to preserve the request hostname. The hostname is used by the s3api middleware to compute and verify the signature. Without this setting it is simply using localhost:8081 which never matches.

Jira: [OSPRH-5835](https://issues.redhat.com//browse/OSPRH-5835)