### PR TITLE
Add ObservedGeneration to the sub Resources

### DIFF
--- a/api/bases/swift.openstack.org_swiftproxies.yaml
+++ b/api/bases/swift.openstack.org_swiftproxies.yaml
@@ -379,6 +379,14 @@ spec:
                   type: array
                 description: NetworkAttachments status of the deployment pods
                 type: object
+              observedGeneration:
+                description: ObservedGeneration - the most recent generation observed
+                  for this service. If the observed generation is less than the spec
+                  generation, then the controller has not processed the latest changes
+                  injected by the opentack-operator in the top-level CR (e.g. the
+                  ContainerImage)
+                format: int64
+                type: integer
               readyCount:
                 description: ReadyCount of SwiftProxy instances
                 format: int32

--- a/api/bases/swift.openstack.org_swiftrings.yaml
+++ b/api/bases/swift.openstack.org_swiftrings.yaml
@@ -131,6 +131,14 @@ spec:
                   type: string
                 description: Map of hashes to track e.g. job status
                 type: object
+              observedGeneration:
+                description: ObservedGeneration - the most recent generation observed
+                  for this service. If the observed generation is less than the spec
+                  generation, then the controller has not processed the latest changes
+                  injected by the opentack-operator in the top-level CR (e.g. the
+                  ContainerImage)
+                format: int64
+                type: integer
             type: object
         type: object
     served: true

--- a/api/bases/swift.openstack.org_swiftstorages.yaml
+++ b/api/bases/swift.openstack.org_swiftstorages.yaml
@@ -161,6 +161,14 @@ spec:
                   type: array
                 description: NetworkAttachments status of the deployment pods
                 type: object
+              observedGeneration:
+                description: ObservedGeneration - the most recent generation observed
+                  for this service. If the observed generation is less than the spec
+                  generation, then the controller has not processed the latest changes
+                  injected by the opentack-operator in the top-level CR (e.g. the
+                  ContainerImage)
+                format: int64
+                type: integer
               readyCount:
                 description: ReadyCount of SwiftStorage instances
                 format: int32

--- a/api/v1beta1/swiftproxy_types.go
+++ b/api/v1beta1/swiftproxy_types.go
@@ -126,6 +126,12 @@ type SwiftProxyStatus struct {
 
 	// TransportURLSecret - Secret containing RabbitMQ transportURL
 	TransportURLSecret string `json:"transportURLSecret,omitempty"`
+
+	// ObservedGeneration - the most recent generation observed for this
+	// service. If the observed generation is less than the spec generation,
+	// then the controller has not processed the latest changes injected by
+	// the opentack-operator in the top-level CR (e.g. the ContainerImage)
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/swiftring_types.go
+++ b/api/v1beta1/swiftring_types.go
@@ -76,6 +76,12 @@ type SwiftRingStatus struct {
 
 	// Map of hashes to track e.g. job status
 	Hash map[string]string `json:"hash,omitempty"`
+
+	// ObservedGeneration - the most recent generation observed for this
+	// service. If the observed generation is less than the spec generation,
+	// then the controller has not processed the latest changes injected by
+	// the opentack-operator in the top-level CR (e.g. the ContainerImage)
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/swiftstorage_types.go
+++ b/api/v1beta1/swiftstorage_types.go
@@ -94,6 +94,12 @@ type SwiftStorageStatus struct {
 
 	// Map of hashes to track e.g. job status
 	Hash map[string]string `json:"hash,omitempty"`
+
+	// ObservedGeneration - the most recent generation observed for this
+	// service. If the observed generation is less than the spec generation,
+	// then the controller has not processed the latest changes injected by
+	// the opentack-operator in the top-level CR (e.g. the ContainerImage)
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/swift.openstack.org_swiftproxies.yaml
+++ b/config/crd/bases/swift.openstack.org_swiftproxies.yaml
@@ -379,6 +379,14 @@ spec:
                   type: array
                 description: NetworkAttachments status of the deployment pods
                 type: object
+              observedGeneration:
+                description: ObservedGeneration - the most recent generation observed
+                  for this service. If the observed generation is less than the spec
+                  generation, then the controller has not processed the latest changes
+                  injected by the opentack-operator in the top-level CR (e.g. the
+                  ContainerImage)
+                format: int64
+                type: integer
               readyCount:
                 description: ReadyCount of SwiftProxy instances
                 format: int32

--- a/config/crd/bases/swift.openstack.org_swiftrings.yaml
+++ b/config/crd/bases/swift.openstack.org_swiftrings.yaml
@@ -131,6 +131,14 @@ spec:
                   type: string
                 description: Map of hashes to track e.g. job status
                 type: object
+              observedGeneration:
+                description: ObservedGeneration - the most recent generation observed
+                  for this service. If the observed generation is less than the spec
+                  generation, then the controller has not processed the latest changes
+                  injected by the opentack-operator in the top-level CR (e.g. the
+                  ContainerImage)
+                format: int64
+                type: integer
             type: object
         type: object
     served: true

--- a/config/crd/bases/swift.openstack.org_swiftstorages.yaml
+++ b/config/crd/bases/swift.openstack.org_swiftstorages.yaml
@@ -161,6 +161,14 @@ spec:
                   type: array
                 description: NetworkAttachments status of the deployment pods
                 type: object
+              observedGeneration:
+                description: ObservedGeneration - the most recent generation observed
+                  for this service. If the observed generation is less than the spec
+                  generation, then the controller has not processed the latest changes
+                  injected by the opentack-operator in the top-level CR (e.g. the
+                  ContainerImage)
+                format: int64
+                type: integer
               readyCount:
                 description: ReadyCount of SwiftStorage instances
                 format: int32

--- a/controllers/swiftring_controller.go
+++ b/controllers/swiftring_controller.go
@@ -137,6 +137,8 @@ func (r *SwiftRingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	)
 
 	instance.Status.Conditions.Init(&cl)
+	// Update the lastObserved generation before evaluating conditions
+	instance.Status.ObservedGeneration = instance.Generation
 
 	// If we're not deleting this and the service object doesn't have our finalizer, add it.
 	if instance.DeletionTimestamp.IsZero() && controllerutil.AddFinalizer(instance, helper.GetFinalizer()) || isNewInstance {


### PR DESCRIPTION
This patch  aligns the swift-operator with the current ObservedGeneration pattern proposed for other operators.
In particular:
1. it adds `observedGeneration` to the sub custom resources
2. it proposes to bump the `observedGeneration` at the beginning of the reconciliation loop (knative/serving#4937)
3. it checks, at the top level, if `ObservedGeneration` matches with the `metadata.generation` assigned to the `subCR(s)`
4. before marking the `DeploymentReadyCondition` as `True`, the `ObservedGeneration` is compared with the `Generation` of the `Deployment`