### PR TITLE
More kuttl tests to verify Barbican, Ceilometer and other customizations

### DIFF
--- a/config/samples/swift_v1beta1_swift.yaml
+++ b/config/samples/swift_v1beta1_swift.yaml
@@ -12,6 +12,3 @@ spec:
     replicas: 1
     passwordSelectors:
       service: SwiftPassword
-    defaultConfigOverwrite:
-      01-proxy-server.conf: |
-        # Additional proxy config

--- a/tests/kuttl/tests/basic-deploy/01-assert-deploy-swift.yaml
+++ b/tests/kuttl/tests/basic-deploy/01-assert-deploy-swift.yaml
@@ -215,11 +215,3 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - script: $SWIFT_KUTTL_DIR/../common/scripts/check_ring_rebalance_output.sh
----
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-commands:
-  - script: |
-      oc rollout status deployment -n $NAMESPACE swift-proxy
-      podname=$(oc get pod -n $NAMESPACE -l component=swift-proxy | grep Running | cut -f 1 -d " ")
-      oc rsh -n $NAMESPACE -c proxy-server "$podname" /bin/sh -c "grep 'Additional proxy config' /etc/swift/proxy-server.conf.d/01-proxy-server.conf"

--- a/tests/kuttl/tests/customization/00-deps.yaml
+++ b/tests/kuttl/tests/customization/00-deps.yaml
@@ -1,0 +1,1 @@
+../../common/00-deps.yaml

--- a/tests/kuttl/tests/customization/01-assert-deploy-swift.yaml
+++ b/tests/kuttl/tests/customization/01-assert-deploy-swift.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: swift.openstack.org/v1beta1
+kind: Swift
+metadata:
+  name: swift
+status:
+  conditions:
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: Ready
+  - message: " Memcached instance has been provisioned"
+    reason: Ready
+    status: "True"
+    type: MemcachedReady
+  - message: RoleBinding created
+    reason: Ready
+    status: "True"
+    type: RoleBindingReady
+  - message: Role created
+    reason: Ready
+    status: "True"
+    type: RoleReady
+  - message: ServiceAccount created
+    reason: Ready
+    status: "True"
+    type: ServiceAccountReady
+  - message: Service config create completed
+    reason: Ready
+    status: "True"
+    type: ServiceConfigReady
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: SwiftProxyReady
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: SwiftRingReady
+  - message: Setup complete
+    reason: Ready
+    status: "True"
+    type: SwiftStorageReady

--- a/tests/kuttl/tests/customization/01-deploy-swift.yaml
+++ b/tests/kuttl/tests/customization/01-deploy-swift.yaml
@@ -2,5 +2,6 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
+      oc apply -n $NAMESPACE -f deploy/swift-conf-secrect.yaml
       cp ../../../../config/samples/swift_v1beta1_swift.yaml deploy
       oc kustomize deploy | oc apply -n $NAMESPACE -f -

--- a/tests/kuttl/tests/customization/01-deploy-swift.yaml
+++ b/tests/kuttl/tests/customization/01-deploy-swift.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      cp ../../../../config/samples/swift_v1beta1_swift.yaml deploy
+      oc kustomize deploy | oc apply -n $NAMESPACE -f -

--- a/tests/kuttl/tests/customization/02-assert-objects.yaml
+++ b/tests/kuttl/tests/customization/02-assert-objects.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: |
+      # Test if objects are retrieved
+      oc debug -n $NAMESPACE --keep-labels=true job/swift-ring-rebalance -- /bin/sh -c "/usr/local/bin/swift-ring-tool get && swift-dispersion-report --object-only | grep '100.00% of object copies found'"

--- a/tests/kuttl/tests/customization/02-create-objects.yaml
+++ b/tests/kuttl/tests/customization/02-create-objects.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: |
+      # Make sure possibly reclaimed PV does not contain any old plaintext data before creating new data
+      oc -n $NAMESPACE rsh -c object-server swift-storage-0 /bin/sh -c "rm -rf /srv/node/pv/objects/*"
+      oc debug -n $NAMESPACE --keep-labels=true job/swift-ring-rebalance -- /bin/sh -c 'swift-ring-tool get && swift-dispersion-populate --object-only'

--- a/tests/kuttl/tests/customization/03-assert-ceilometer.yaml
+++ b/tests/kuttl/tests/customization/03-assert-ceilometer.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: |
+      oc -n $NAMESPACE rsh rabbitmq-server-0 /bin/sh -c "rabbitmqadmin get queue=notifications.info" | grep swift

--- a/tests/kuttl/tests/customization/03-test-ceilometer.yaml
+++ b/tests/kuttl/tests/customization/03-test-ceilometer.yaml
@@ -1,0 +1,1 @@
+# Placeholder to set kuttl test name in logs

--- a/tests/kuttl/tests/customization/04-assert-encryption.yaml
+++ b/tests/kuttl/tests/customization/04-assert-encryption.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: |
+      # Ensure objects are not saved in plaintext
+      oc -n $NAMESPACE rsh -c object-server swift-storage-0 /bin/sh -c "! grep -r dispersion /srv/node/pv/objects/*"

--- a/tests/kuttl/tests/customization/04-test-encryption.yaml
+++ b/tests/kuttl/tests/customization/04-test-encryption.yaml
@@ -1,0 +1,1 @@
+# Placeholder to set kuttl test name in logs

--- a/tests/kuttl/tests/customization/05-assert-containersharder.yaml
+++ b/tests/kuttl/tests/customization/05-assert-containersharder.yaml
@@ -1,0 +1,143 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: swift-storage
+    service: swift
+  name: swift-storage-0
+spec:
+  containers:
+  - command:
+    - /usr/bin/swift-account-server
+    - /etc/swift/account-server.conf.d
+    - -v
+    name: account-server
+  - command:
+    - /usr/bin/swift-account-replicator
+    - /etc/swift/account-server.conf.d
+    - -v
+    name: account-replicator
+  - command:
+    - /usr/bin/swift-account-auditor
+    - /etc/swift/account-server.conf.d
+    - -v
+    name: account-auditor
+  - command:
+    - /usr/bin/swift-account-reaper
+    - /etc/swift/account-server.conf.d
+    - -v
+    name: account-reaper
+  - command:
+    - /usr/bin/swift-container-server
+    - /etc/swift/container-server.conf.d
+    - -v
+    name: container-server
+  - command:
+    - /usr/bin/swift-container-replicator
+    - /etc/swift/container-server.conf.d
+    - -v
+    name: container-replicator
+  - command:
+    - /usr/bin/swift-container-auditor
+    - /etc/swift/container-server.conf.d
+    - -v
+    name: container-auditor
+  - command:
+    - /usr/bin/swift-container-updater
+    - /etc/swift/container-server.conf.d
+    - -v
+    name: container-updater
+  - command:
+    - /usr/bin/swift-object-server
+    - /etc/swift/object-server.conf.d
+    - -v
+    name: object-server
+  - command:
+    - /usr/bin/swift-object-replicator
+    - /etc/swift/object-server.conf.d
+    - -v
+    name: object-replicator
+  - command:
+    - /usr/bin/swift-object-auditor
+    - /etc/swift/object-server.conf.d
+    - -v
+    name: object-auditor
+  - command:
+    - /usr/bin/swift-object-updater
+    - /etc/swift/object-server.conf.d
+    - -v
+    name: object-updater
+  - command:
+    - /usr/bin/swift-object-expirer
+    - /etc/swift/object-expirer.conf.d
+    - -v
+    name: object-expirer
+  - command:
+    - /usr/bin/rsync
+    - --daemon
+    - --no-detach
+    - --config=/etc/swift/rsyncd.conf
+    - --log-file=/dev/stdout
+    name: rsync
+  - command:
+    - sh
+    - -c
+    - while true; do /usr/bin/swift-recon-cron /etc/swift/object-server.conf.d
+      -v; sleep 300; done
+    name: swift-recon-cron
+  - command:
+    - /usr/bin/swift-container-sharder
+    - /etc/swift/container-server.conf.d
+    - -v
+    name: container-sharder
+status:
+  containerStatuses:
+    - name: account-auditor
+      ready: true
+      started: true
+    - name: account-reaper
+      ready: true
+      started: true
+    - name: account-replicator
+      ready: true
+      started: true
+    - name: account-server
+      ready: true
+      started: true
+    - name: container-auditor
+      ready: true
+      started: true
+    - name: container-replicator
+      ready: true
+      started: true
+    - name: container-server
+      ready: true
+      started: true
+    - name: container-sharder
+      ready: true
+      started: true
+    - name: container-updater
+      ready: true
+      started: true
+    - name: object-auditor
+      ready: true
+      started: true
+    - name: object-expirer
+      ready: true
+      started: true
+    - name: object-replicator
+      ready: true
+      started: true
+    - name: object-server
+      ready: true
+      started: true
+    - name: object-updater
+      ready: true
+      started: true
+    - name: rsync
+      ready: true
+      started: true
+    - name: swift-recon-cron
+      ready: true
+      started: true

--- a/tests/kuttl/tests/customization/05-test-containersharder.yaml
+++ b/tests/kuttl/tests/customization/05-test-containersharder.yaml
@@ -1,0 +1,1 @@
+# Placeholder to set kuttl test name in logs

--- a/tests/kuttl/tests/customization/06-assert-customization.yaml
+++ b/tests/kuttl/tests/customization/06-assert-customization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: |
+      oc rsh -n $NAMESPACE -c account-server swift-storage-0 /bin/sh -c "ps --no-headers -C swift-account-server" | [ `wc -l` -eq 4 ]
+  - script: |
+      oc rsh -n $NAMESPACE -c container-server swift-storage-0 /bin/sh -c "ps --no-headers -C swift-container-server" | [ `wc -l` -eq 4 ]
+  - script: |
+      oc rsh -n $NAMESPACE -c object-server swift-storage-0 /bin/sh -c "ps --no-headers -C swift-object-server" | [ `wc -l` -eq 4 ]
+  - script: |
+      podname=$(oc get pod -n $NAMESPACE -l component=swift-proxy | grep Running | cut -f 1 -d " ")
+      oc rsh -n $NAMESPACE -c proxy-server $podname /bin/sh -c "ps --no-headers -C swift-proxy-server" | [ `wc -l` -eq 4 ]

--- a/tests/kuttl/tests/customization/06-test-customization.yaml
+++ b/tests/kuttl/tests/customization/06-test-customization.yaml
@@ -1,0 +1,1 @@
+# Placeholder to set kuttl test name in logs

--- a/tests/kuttl/tests/customization/07-assert-custom-swiftconf.yaml
+++ b/tests/kuttl/tests/customization/07-assert-custom-swiftconf.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: |
+      oc extract -n $NAMESPACE secret/swift-conf --to=- | grep -z "some.*secret"

--- a/tests/kuttl/tests/customization/07-test-custom-swiftconf.yaml
+++ b/tests/kuttl/tests/customization/07-test-custom-swiftconf.yaml
@@ -1,0 +1,1 @@
+# Placeholder to set kuttl test name in logs

--- a/tests/kuttl/tests/customization/08-assert-ringsettings.yaml
+++ b/tests/kuttl/tests/customization/08-assert-ringsettings.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: |
+      oc wait --for=condition=Ready -n $NAMESPACE Swift swift
+  - script: |
+      oc debug -n $NAMESPACE --keep-labels=true job/swift-ring-rebalance -- /bin/sh -c "/usr/local/bin/swift-ring-tool get && swift-ring-builder object.builder" | grep -z "4 partitions.*reassigned is 2"

--- a/tests/kuttl/tests/customization/08-test-ringsettings.yaml
+++ b/tests/kuttl/tests/customization/08-test-ringsettings.yaml
@@ -1,0 +1,1 @@
+# Placeholder to set kuttl test name in logs

--- a/tests/kuttl/tests/customization/09-cleanup.yaml
+++ b/tests/kuttl/tests/customization/09-cleanup.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+- apiVersion: swift.openstack.org/v1beta1
+  kind: Swift
+  name: swift
+commands:
+- script: |
+    oc delete --ignore-not-found=true -n $NAMESPACE pvc swift-swift-storage-0
+    for pv in $(oc get pv | grep "Released.*swift" | cut -f 1 -d " "); do oc patch pv $pv -p '{"spec":{"claimRef": null}}'; done

--- a/tests/kuttl/tests/customization/09-cleanup.yaml
+++ b/tests/kuttl/tests/customization/09-cleanup.yaml
@@ -6,5 +6,6 @@ delete:
   name: swift
 commands:
 - script: |
+    oc delete --ignore-not-found=true -n $NAMESPACE secret swift-conf
     oc delete --ignore-not-found=true -n $NAMESPACE pvc swift-swift-storage-0
     for pv in $(oc get pv | grep "Released.*swift" | cut -f 1 -d " "); do oc patch pv $pv -p '{"spec":{"claimRef": null}}'; done

--- a/tests/kuttl/tests/customization/09-errors-cleanup.yaml
+++ b/tests/kuttl/tests/customization/09-errors-cleanup.yaml
@@ -1,0 +1,15 @@
+apiVersion: swift.openstack.org/v1beta1
+kind: Swift
+metadata:
+  name: swift
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app.kubernetes.io/name: SwiftProxy
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: swift-storage-0

--- a/tests/kuttl/tests/customization/deploy/kustomization.yaml
+++ b/tests/kuttl/tests/customization/deploy/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ./swift_v1beta1_swift.yaml
+patches:
+- patch: |-
+    - op: replace
+      path: /spec/swiftRing/partPower
+      value: 2
+    - op: replace
+      path: /spec/swiftProxy/ceilometerEnabled
+      value: true
+  target:
+    kind: Swift

--- a/tests/kuttl/tests/customization/deploy/kustomization.yaml
+++ b/tests/kuttl/tests/customization/deploy/kustomization.yaml
@@ -8,6 +8,9 @@ patches:
       path: /spec/swiftRing/partPower
       value: 2
     - op: replace
+      path: /spec/swiftRing/minPartHours
+      value: 2
+    - op: replace
       path: /spec/swiftProxy/ceilometerEnabled
       value: true
     - op: replace

--- a/tests/kuttl/tests/customization/deploy/kustomization.yaml
+++ b/tests/kuttl/tests/customization/deploy/kustomization.yaml
@@ -16,5 +16,23 @@ patches:
     - op: replace
       path: /spec/swiftStorage/containerSharderEnabled
       value: true
+    - op: add
+      path: /spec/swiftProxy/defaultConfigOverwrite
+      value:
+        01-proxy-server.conf: |
+          [DEFAULT]
+          workers = 3
+    - op: add
+      path: /spec/swiftStorage/defaultConfigOverwrite
+      value:
+        01-account-server.conf: |
+          [DEFAULT]
+          workers = 3
+        01-container-server.conf: |
+          [DEFAULT]
+          workers = 3
+        01-object-server.conf: |
+          [DEFAULT]
+          workers = 3
   target:
     kind: Swift

--- a/tests/kuttl/tests/customization/deploy/kustomization.yaml
+++ b/tests/kuttl/tests/customization/deploy/kustomization.yaml
@@ -13,5 +13,8 @@ patches:
     - op: replace
       path: /spec/swiftProxy/encryptionEnabled
       value: true
+    - op: replace
+      path: /spec/swiftStorage/containerSharderEnabled
+      value: true
   target:
     kind: Swift

--- a/tests/kuttl/tests/customization/deploy/kustomization.yaml
+++ b/tests/kuttl/tests/customization/deploy/kustomization.yaml
@@ -10,5 +10,8 @@ patches:
     - op: replace
       path: /spec/swiftProxy/ceilometerEnabled
       value: true
+    - op: replace
+      path: /spec/swiftProxy/encryptionEnabled
+      value: true
   target:
     kind: Swift

--- a/tests/kuttl/tests/customization/deploy/swift-conf-secrect.yaml
+++ b/tests/kuttl/tests/customization/deploy/swift-conf-secrect.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: swift-conf
+data:
+  swift.conf: W3N3aWZ0LWhhc2hdCnN3aWZ0X2hhc2hfcGF0aF9zdWZmaXggPSBzb21lCnN3aWZ0X2hhc2hfcGF0aF9wcmVmaXggPSBzZWNyZXQK


### PR DESCRIPTION
Adds a bunch of tests to verify customization settings. Most of these settings do exist in a similar way in TripleO, thus making sure these options do still work.

- Add kuttl test to verify ceilometermiddleware integration
- Add kuttl test to verify object encryption using Barbican
- Add kuttl test to verify container sharder enablement
- Add kuttl test to verify config customization
- Add kuttl test to verify custom swift.conf
- Add kuttl test to verify ring settings

The last test needs #201 to be merged first.
