### PR TITLE
Move to golangci-lint-full

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
 - repo: https://github.com/golangci/golangci-lint
   rev: v1.55.2
   hooks:
-    - id: golangci-lint
+    - id: golangci-lint-full
       args: ["-v"]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/controllers/swift_controller.go
+++ b/controllers/swift_controller.go
@@ -157,7 +157,7 @@ func (r *SwiftReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resu
 
 	// Handle service delete
 	if !instance.DeletionTimestamp.IsZero() {
-		return r.reconcileDelete(ctx, instance, helper)
+		return r.reconcileDelete(instance, helper)
 	}
 
 	// Handle non-deleted clusters
@@ -405,7 +405,7 @@ func (r *SwiftReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *SwiftReconciler) reconcileDelete(ctx context.Context, instance *swiftv1.Swift, helper *helper.Helper) (ctrl.Result, error) {
+func (r *SwiftReconciler) reconcileDelete(instance *swiftv1.Swift, helper *helper.Helper) (ctrl.Result, error) {
 	r.Log.Info(fmt.Sprintf("Reconciling Service '%s' delete", instance.Name))
 
 	// Service is deleted so remove the finalizer.

--- a/controllers/swiftproxy_controller.go
+++ b/controllers/swiftproxy_controller.go
@@ -584,7 +584,7 @@ func (r *SwiftProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	// create hash over all the different input resources to identify if any those changed
 	// and a restart/recreate is required.
-	inputHash, hashChanged, err := r.createHashOfInputHashes(ctx, instance, envVars)
+	inputHash, hashChanged, err := r.createHashOfInputHashes(instance, envVars)
 	if err != nil {
 		return ctrl.Result{}, err
 	} else if hashChanged {
@@ -799,7 +799,7 @@ func (r *SwiftProxyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *SwiftProxyReconciler) findObjectsForSrc(ctx context.Context, src client.Object) []reconcile.Request {
 	requests := []reconcile.Request{}
 
-	l := log.FromContext(context.Background()).WithName("Controllers").WithName("SwiftProxy")
+	l := log.FromContext(ctx).WithName("Controllers").WithName("SwiftProxy")
 
 	for _, field := range swiftProxyWatchFields {
 		crList := &swiftv1beta1.SwiftProxyList{}
@@ -807,7 +807,7 @@ func (r *SwiftProxyReconciler) findObjectsForSrc(ctx context.Context, src client
 			FieldSelector: fields.OneTermEqualSelector(field, src.GetName()),
 			Namespace:     src.GetNamespace(),
 		}
-		err := r.List(context.TODO(), crList, listOps)
+		err := r.List(ctx, crList, listOps)
 		if err != nil {
 			return []reconcile.Request{}
 		}
@@ -877,7 +877,6 @@ func (r *SwiftProxyReconciler) reconcileDelete(ctx context.Context, instance *sw
 //
 // returns the hash, whether the hash changed (as a bool) and any error
 func (r *SwiftProxyReconciler) createHashOfInputHashes(
-	ctx context.Context,
 	instance *swiftv1beta1.SwiftProxy,
 	envVars map[string]env.Setter,
 ) (string, bool, error) {

--- a/controllers/swiftstorage_controller.go
+++ b/controllers/swiftstorage_controller.go
@@ -278,7 +278,7 @@ func (r *SwiftStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Limit internal storage traffic to Swift services
-	np := swiftstorage.NewNetworkPolicy(swiftstorage.NetworkPolicy(instance, storageNetworkRange), serviceLabels, 5*time.Second)
+	np := swiftstorage.NewNetworkPolicy(swiftstorage.NetworkPolicy(instance, storageNetworkRange), 5*time.Second)
 	ctrlResult, err = np.CreateOrPatch(ctx, helper)
 	if err != nil {
 		return ctrlResult, err
@@ -374,7 +374,6 @@ func (r *SwiftStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				helper,
 				hostName,
 				dnsIP,
-				instance,
 				swiftPod,
 				serviceLabels,
 			)

--- a/pkg/swiftstorage/dnsdata.go
+++ b/pkg/swiftstorage/dnsdata.go
@@ -6,7 +6,6 @@ import (
 
 	infranetworkv1 "github.com/openstack-k8s-operators/infra-operator/apis/network/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
-	swiftv1 "github.com/openstack-k8s-operators/swift-operator/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -18,7 +17,6 @@ func DNSData(
 	helper *helper.Helper,
 	hostName string,
 	ip string,
-	instance *swiftv1.SwiftStorage,
 	swiftPod corev1.Pod,
 	serviceLabels map[string]string,
 ) error {

--- a/pkg/swiftstorage/networkpolicy.go
+++ b/pkg/swiftstorage/networkpolicy.go
@@ -130,7 +130,6 @@ type NetworkPolicyStruct struct {
 // NewNetworkPolicy returns an initialized NetworkPolicy.
 func NewNetworkPolicy(
 	networkPolicy *networkingv1.NetworkPolicy,
-	labels map[string]string,
 	timeout time.Duration,
 ) *NetworkPolicyStruct {
 	return &NetworkPolicyStruct{

--- a/tests/functional/suite_test.go
+++ b/tests/functional/suite_test.go
@@ -26,8 +26,9 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo/v2" //revive:disable:dot-imports
+	. "github.com/onsi/gomega"    //revive:disable:dot-imports
+	//revive:disable-next-line:dot-imports
 	. "github.com/openstack-k8s-operators/lib-common/modules/common/test/helpers"
 
 	"k8s.io/client-go/kubernetes"


### PR DESCRIPTION
This patch moves the pre-commit-config to golangci-lint-full and clean up most of the code leftovers.
In particular:
- unused func params are removed
- better use of ctx context.Context
- fix revive error for envTests