### PR TITLE
Add nodename as metadata to Swift rings

### DIFF
--- a/pkg/swiftring/funcs.go
+++ b/pkg/swiftring/funcs.go
@@ -67,8 +67,17 @@ func DeviceList(ctx context.Context, h *helper.Helper, instance *swiftv1beta1.Sw
 			capacity := foundClaim.Status.Capacity[corev1.ResourceStorage]
 			weight, _ := capacity.AsInt64()
 			weight = weight / (1000 * 1000 * 1000) // 10GiB gets a weight of 10 etc.
-			// Format: region zone hostname devicename weight
-			devices = append(devices, fmt.Sprintf("1 1 %s-%d.%s.%s.svc pv %d\n", storageInstance.Name, replica, storageInstance.Name, storageInstance.Namespace, weight))
+
+			podName := fmt.Sprintf("%s-%d", storageInstance.Name, replica)
+			foundPod := &corev1.Pod{}
+			err = h.GetClient().Get(ctx, types.NamespacedName{Name: podName, Namespace: storageInstance.Namespace}, foundPod)
+			if err != nil {
+				err = fmt.Errorf("Pod %s not found", podName)
+				return "", "", err
+			}
+
+			// Format: region zone hostname devicename weight nodename
+			devices = append(devices, fmt.Sprintf("1 1 %s-%d.%s.%s.svc pv %d %s\n", storageInstance.Name, replica, storageInstance.Name, storageInstance.Namespace, weight, foundPod.Spec.NodeName))
 		}
 	}
 

--- a/templates/swiftring/bin/swift-ring-tool
+++ b/templates/swiftring/bin/swift-ring-tool
@@ -54,18 +54,18 @@ function init() {
 
 function update() {
     # Iterate over all devices from the list created by the SwiftStorage CR.
-    while read REGION ZONE HOST DEVICE_NAME WEIGHT; do
+    while read REGION ZONE HOST DEVICE_NAME WEIGHT NODE; do
         # Check if host/disk exists and only add if not
         swift-ring-builder account.builder search --ip $HOST --device $DEVICE_NAME
-        [ $? -eq 2 ] && swift-ring-builder account.builder add --region $REGION --zone $ZONE --ip $HOST --port 6202 --device $DEVICE_NAME --weight $WEIGHT
+        [ $? -eq 2 ] && swift-ring-builder account.builder add --region $REGION --zone $ZONE --ip $HOST --port 6202 --device $DEVICE_NAME --weight $WEIGHT --meta $NODE
 
         # Check if host/disk exists and only add if not
         swift-ring-builder container.builder search --ip $HOST --device $DEVICE_NAME
-        [ $? -eq 2 ] && swift-ring-builder container.builder add --region $REGION --zone $ZONE --ip $HOST --port 6201 --device $DEVICE_NAME --weight $WEIGHT
+        [ $? -eq 2 ] && swift-ring-builder container.builder add --region $REGION --zone $ZONE --ip $HOST --port 6201 --device $DEVICE_NAME --weight $WEIGHT --meta $NODE
 
         # Check if host/disk exists and only add if not
         swift-ring-builder object.builder search --ip $HOST --device $DEVICE_NAME
-        [ $? -eq 2 ] && swift-ring-builder object.builder add --region $REGION --zone $ZONE --ip $HOST --port 6200 --device $DEVICE_NAME --weight $WEIGHT
+        [ $? -eq 2 ] && swift-ring-builder object.builder add --region $REGION --zone $ZONE --ip $HOST --port 6200 --device $DEVICE_NAME --weight $WEIGHT --meta $NODE
 done < $DEVICESFILE
 }
 


### PR DESCRIPTION
The nodename will be used later on to improve rebalancing to avoid assigning multiple replicas to the same node. Adding this data now to avoid adding a ring upgrade mechanism later on; once devices are added to the rings they won't be changed anymore by the operator.