### PR TITLE
Fix unscheduled podname issue when building Swift rings

### DIFF
--- a/pkg/swiftring/funcs.go
+++ b/pkg/swiftring/funcs.go
@@ -75,6 +75,10 @@ func DeviceList(ctx context.Context, h *helper.Helper, instance *swiftv1beta1.Sw
 				err = fmt.Errorf("Pod %s not found", podName)
 				return "", "", err
 			}
+			if foundPod.Spec.NodeName == "" {
+				err = fmt.Errorf("Pod %s found, but NodeName not yet set. Requeueing", podName)
+				return "", "", err // requeueing
+			}
 
 			// Format: region zone hostname devicename weight nodename
 			devices = append(devices, fmt.Sprintf("1 1 %s-%d.%s.%s.svc pv %d %s\n", storageInstance.Name, replica, storageInstance.Name, storageInstance.Namespace, weight, foundPod.Spec.NodeName))

--- a/templates/swiftring/bin/swift-ring-tool
+++ b/templates/swiftring/bin/swift-ring-tool
@@ -57,15 +57,15 @@ function update() {
     while read REGION ZONE HOST DEVICE_NAME WEIGHT NODE; do
         # Check if host/disk exists and only add if not
         swift-ring-builder account.builder search --ip $HOST --device $DEVICE_NAME
-        [ $? -eq 2 ] && swift-ring-builder account.builder add --region $REGION --zone $ZONE --ip $HOST --port 6202 --device $DEVICE_NAME --weight $WEIGHT --meta $NODE
+        [ $? -eq 2 ] && swift-ring-builder account.builder add --region $REGION --zone $ZONE --ip $HOST --port 6202 --device $DEVICE_NAME --weight $WEIGHT --meta "$NODE"
 
         # Check if host/disk exists and only add if not
         swift-ring-builder container.builder search --ip $HOST --device $DEVICE_NAME
-        [ $? -eq 2 ] && swift-ring-builder container.builder add --region $REGION --zone $ZONE --ip $HOST --port 6201 --device $DEVICE_NAME --weight $WEIGHT --meta $NODE
+        [ $? -eq 2 ] && swift-ring-builder container.builder add --region $REGION --zone $ZONE --ip $HOST --port 6201 --device $DEVICE_NAME --weight $WEIGHT --meta "$NODE"
 
         # Check if host/disk exists and only add if not
         swift-ring-builder object.builder search --ip $HOST --device $DEVICE_NAME
-        [ $? -eq 2 ] && swift-ring-builder object.builder add --region $REGION --zone $ZONE --ip $HOST --port 6200 --device $DEVICE_NAME --weight $WEIGHT --meta $NODE
+        [ $? -eq 2 ] && swift-ring-builder object.builder add --region $REGION --zone $ZONE --ip $HOST --port 6200 --device $DEVICE_NAME --weight $WEIGHT --meta "$NODE"
 done < $DEVICESFILE
 }
 


### PR DESCRIPTION
Fixes an issue if the Pod nodename is not yet set, for example if the Pod is already created but not yet assigned to a node. In that case the swift-ring-builder will fail with "error: --meta option requires 1 argument".