### PR TITLE
Fix Pod watch RBAC error

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,6 +12,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/controllers/swiftstorage_controller.go
+++ b/controllers/swiftstorage_controller.go
@@ -83,7 +83,7 @@ type Netconfig struct {
 //+kubebuilder:rbac:groups=memcached.openstack.org,resources=memcacheds,verbs=get;list;watch;
 //+kubebuilder:rbac:groups=network.openstack.org,resources=dnsdata,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list
-//+kubebuilder:rbac:groups="",resources=pods,verbs=get;list
+//+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
Commit a987062 restricted the RBAC permissions for Pods to Get and List operations, as these are the only ones required by the swift-operator itself. However, Get/List operations are using an informerCache, which itself sets up a Watch to the objects. Without the required watch permission this throws an error in the operator log like this:

    Failed to watch *v1.Pod: unknown (get pods)

Example: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openstack-k8s-operators_swift-operator/213/pull-ci-openstack-k8s-operators-swift-operator-main-swift-operator-build-deploy-kuttl/1783865524250218496/artifacts/swift-operator-build-deploy-kuttl/openstack-k8s-operators-gather/artifacts/must-gather/quay-io-openstack-k8s-operators-openstack-must-gather-sha256-3b72ed0efad07dbb323ccf122626a766a9a7838b61c98ec42bcaf6e0d789f497/namespaces/openstack-operators/pods/swift-operator-controller-manager-5f5dcb586d-nmsjh/logs/manager.log