### PR TITLE
Allow to scale down SwiftStorage replicas

### DIFF
--- a/api/v1beta1/swift_webhook.go
+++ b/api/v1beta1/swift_webhook.go
@@ -184,13 +184,6 @@ func (r *Swift) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
 func (r *SwiftSpec) ValidateUpdate(old SwiftSpec, basePath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	if *r.SwiftStorage.Replicas < *old.SwiftStorage.Replicas {
-		allErrs = append(allErrs, field.Invalid(
-			basePath.Child("swiftStorage").Child("replicas"),
-			*r.SwiftStorage.Replicas,
-			"SwiftStorage does not support scale-in"))
-	}
-
 	// validate the service override key is valid
 	allErrs = append(allErrs, service.ValidateRoutedOverrides(
 		basePath.Child("swiftProxy").Child("override").Child("service"),
@@ -201,13 +194,6 @@ func (r *SwiftSpec) ValidateUpdate(old SwiftSpec, basePath *field.Path) field.Er
 
 func (r *SwiftSpecCore) ValidateUpdate(old SwiftSpecCore, basePath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
-
-	if *r.SwiftStorage.Replicas < *old.SwiftStorage.Replicas {
-		allErrs = append(allErrs, field.Invalid(
-			basePath.Child("swiftStorage").Child("replicas"),
-			*r.SwiftStorage.Replicas,
-			"SwiftStorage does not support scale-in"))
-	}
 
 	// validate the service override key is valid
 	allErrs = append(allErrs, service.ValidateRoutedOverrides(


### PR DESCRIPTION
If `swift` is not explicitly created in the `ctlplane` (`enabled: false`), we still get it as part of the `OpenStackControPlane`, and `swiftStorage` has `replicas: 1`.
This is problematic in adoption, where if we get `replica: 1` by default, we fail later in the process when we try to only enable `SwiftProxy` and pass `replicas: 0` to `SwiftStorage` (the `Webhook` denies `scale-in`).
Given that `SwiftStorage` is a `StatefulSet`[1], we preserve network and storage properties, and it might be possible that we want to simply turn off an instance for troubleshooting purposes, so this patch removes the webhook check.

[1] https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/

Jira: https://issues.redhat.com/browse/OSPCIX-320