### PR TITLE
Standardize swift-ring finalizer name

### DIFF
--- a/controllers/swiftring_controller.go
+++ b/controllers/swiftring_controller.go
@@ -255,7 +255,7 @@ func (r *SwiftRingReconciler) reconcileDelete(ctx context.Context, instance *swi
 	if err == nil {
 		// This finalizer is directly set when creating the ConfigMap using
 		// curl within the Job
-		if controllerutil.RemoveFinalizer(ringConfigMap, "swift-ring/finalizer") {
+		if controllerutil.RemoveFinalizer(ringConfigMap, "openstack.org/swiftring") {
 			err = r.Update(ctx, ringConfigMap)
 			if err != nil && !apierrors.IsNotFound(err) {
 				return ctrl.Result{}, err

--- a/templates/swiftring/bin/swift-ring-tool
+++ b/templates/swiftring/bin/swift-ring-tool
@@ -122,7 +122,7 @@ function push() {
             '${VERSION}'
             "name":"'${CM_NAME}'",
             "namespace":"'${NAMESPACE}'",
-            "finalizers": ["swift-ring/finalizer"],
+            "finalizers": ["openstack.org/swiftring"],
             "ownerReferences": [
                 {
                     "apiVersion": "'${OWNER_APIVERSION}'",


### PR DESCRIPTION
The swift-ring finalizer is created by a curl API request and not using lib-common. This patch standardizes the finalizer name by adding the missing domain name.

Related: https://github.com/openstack-k8s-operators/lib-common/pull/519