### PR TITLE
[OSPRH-8705] Fix SwiftStorage replicas update nil pointer

### DIFF
--- a/api/v1beta1/swift_webhook.go
+++ b/api/v1beta1/swift_webhook.go
@@ -184,10 +184,22 @@ func (r *Swift) ValidateUpdate(old runtime.Object) (admission.Warnings, error) {
 func (r *SwiftSpec) ValidateUpdate(old SwiftSpec, basePath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	if *r.SwiftStorage.Replicas < *old.SwiftStorage.Replicas {
+	zeroVal := int32(0)
+	oldReplicas := old.SwiftStorage.Replicas
+	newReplicas := r.SwiftStorage.Replicas
+
+	if oldReplicas == nil {
+		oldReplicas = &zeroVal
+	}
+
+	if newReplicas == nil {
+		newReplicas = &zeroVal
+	}
+
+	if *newReplicas < *oldReplicas {
 		allErrs = append(allErrs, field.Invalid(
 			basePath.Child("swiftStorage").Child("replicas"),
-			*r.SwiftStorage.Replicas,
+			*newReplicas,
 			"SwiftStorage does not support scale-in"))
 	}
 
@@ -202,10 +214,22 @@ func (r *SwiftSpec) ValidateUpdate(old SwiftSpec, basePath *field.Path) field.Er
 func (r *SwiftSpecCore) ValidateUpdate(old SwiftSpecCore, basePath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	if *r.SwiftStorage.Replicas < *old.SwiftStorage.Replicas {
+	zeroVal := int32(0)
+	oldReplicas := old.SwiftStorage.Replicas
+	newReplicas := r.SwiftStorage.Replicas
+
+	if oldReplicas == nil {
+		oldReplicas = &zeroVal
+	}
+
+	if newReplicas == nil {
+		newReplicas = &zeroVal
+	}
+
+	if *newReplicas < *oldReplicas {
 		allErrs = append(allErrs, field.Invalid(
 			basePath.Child("swiftStorage").Child("replicas"),
-			*r.SwiftStorage.Replicas,
+			*newReplicas,
 			"SwiftStorage does not support scale-in"))
 	}
 


### PR DESCRIPTION
If the `OpenStackControlPlane` CR's `spec.swift.template` section is missing, trying to `oc patch` it fails due to a nil-pointer on the server side.

Jira: https://issues.redhat.com/browse/OSPRH-8705