### PR TITLE
Fix race condition in kuttl tests

### DIFF
--- a/tests/kuttl/tests/basic-deploy/02-assert-scaleup-swift.yaml
+++ b/tests/kuttl/tests/basic-deploy/02-assert-scaleup-swift.yaml
@@ -26,4 +26,6 @@ commands:
   - script: |
       oc wait -n $NAMESPACE --for=condition=Ready Swift swift
   - script: |
+      oc wait -n $NAMESPACE --for=condition=complete job swift-ring-rebalance
+  - script: |
       oc debug -n $NAMESPACE --keep-labels=true job/swift-ring-rebalance -- /bin/sh -c "/usr/local/bin/swift-ring-tool get && swift-ring-builder object.builder" | grep -z "3 devices"

--- a/tests/kuttl/tests/customization/02-assert-objects.yaml
+++ b/tests/kuttl/tests/customization/02-assert-objects.yaml
@@ -3,5 +3,7 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - script: |
+      oc wait -n $NAMESPACE --for=condition=complete job swift-ring-rebalance
+  - script: |
       # Test if objects are retrieved
       oc debug -n $NAMESPACE --keep-labels=true job/swift-ring-rebalance -- /bin/sh -c "/usr/local/bin/swift-ring-tool get && swift-dispersion-report --object-only | grep '100.00% of object copies found'"

--- a/tests/kuttl/tests/customization/02-create-objects.yaml
+++ b/tests/kuttl/tests/customization/02-create-objects.yaml
@@ -3,6 +3,8 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
+      oc wait -n $NAMESPACE --for=condition=complete job swift-ring-rebalance
+  - script: |
       # Make sure possibly reclaimed PV does not contain any old plaintext data before creating new data
       oc -n $NAMESPACE rsh -c object-server swift-storage-0 /bin/sh -c "rm -rf /srv/node/pv/objects/*"
       oc debug -n $NAMESPACE --keep-labels=true job/swift-ring-rebalance -- /bin/sh -c 'swift-ring-tool get && swift-dispersion-populate --object-only'

--- a/tests/kuttl/tests/customization/08-assert-ringsettings.yaml
+++ b/tests/kuttl/tests/customization/08-assert-ringsettings.yaml
@@ -5,4 +5,6 @@ commands:
   - script: |
       oc wait --for=condition=Ready -n $NAMESPACE Swift swift
   - script: |
+      oc wait -n $NAMESPACE --for=condition=complete job swift-ring-rebalance
+  - script: |
       oc debug -n $NAMESPACE --keep-labels=true job/swift-ring-rebalance -- /bin/sh -c "/usr/local/bin/swift-ring-tool get && swift-ring-builder object.builder" | grep -z "4 partitions.*reassigned is 2"

--- a/tests/kuttl/tests/replication/02-assert-store-data.yaml
+++ b/tests/kuttl/tests/replication/02-assert-store-data.yaml
@@ -3,4 +3,6 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - script: |
+      oc wait -n $NAMESPACE --for=condition=complete job swift-ring-rebalance
+  - script: |
       oc debug -n $NAMESPACE --keep-labels=true job/swift-ring-rebalance -- /bin/sh -c 'swift-ring-tool get && swift-dispersion-report --object-only' | grep '100.00% of object copies found'

--- a/tests/kuttl/tests/replication/02-store-data.yaml
+++ b/tests/kuttl/tests/replication/02-store-data.yaml
@@ -3,4 +3,6 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: |
+      oc wait -n $NAMESPACE --for=condition=complete job swift-ring-rebalance
+  - script: |
       oc debug -n $NAMESPACE --keep-labels=true job/swift-ring-rebalance -- /bin/sh -c 'swift-ring-tool get && swift-dispersion-populate --object-only'

--- a/tests/kuttl/tests/replication/03-assert-force-replication.yaml
+++ b/tests/kuttl/tests/replication/03-assert-force-replication.yaml
@@ -3,4 +3,6 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - script: |
+      oc wait -n $NAMESPACE --for=condition=complete job swift-ring-rebalance
+  - script: |
       oc debug -n $NAMESPACE --keep-labels=true job/swift-ring-rebalance -- /bin/sh -c 'swift-ring-tool get && swift-dispersion-report --object-only' | grep '100.00% of object copies found'


### PR DESCRIPTION
The debug command requires an existing job, however this might no longer be the case when testing. This commit removes the dependency on the job pod to stabilize tests.

It uses the proxy pod to run basically the same tests. The debug command is still used to ensure a new pod with the latest rings is used to run tests.

Also removing an unneeded test script which is not needed. If the ring got not properly created and rebalanced, all other tests would fail as well.

Related: openstack-k8s-operators/swift-operator#239