### PR TITLE
Fix race condition if ring rebalance is needed

### DIFF
--- a/controllers/swiftring_controller.go
+++ b/controllers/swiftring_controller.go
@@ -202,8 +202,10 @@ func (r *SwiftRingReconciler) reconcileNormal(ctx context.Context, instance *swi
 					return ctrl.Result{}, err
 				}
 			}
+			return ctrl.Result{}, nil
 		}
 
+		// will only be updated if job does not exist (anymore)
 		instance.Status.Hash[swiftv1beta1.RingCreateHash] = ""
 		instance.Status.Hash[swiftv1beta1.DeviceListHash] = deviceListHash
 	}


### PR DESCRIPTION
If a rebalance is needed and the job has to re-run, it will be deleted first. Deletes are executed using a background deletion policy, thus a deleted job might still exist and if the operator tries to re-create it, it will immediately become succesful (and not executed at all).

This commit changes the behaviour to reconcile again if the job does exist.