### PR TITLE
Make sure to log error in findObjectsForSrc()

### DIFF
--- a/controllers/swiftproxy_controller.go
+++ b/controllers/swiftproxy_controller.go
@@ -803,7 +803,8 @@ func (r *SwiftProxyReconciler) findObjectsForSrc(ctx context.Context, src client
 		}
 		err := r.List(ctx, crList, listOps)
 		if err != nil {
-			return []reconcile.Request{}
+			l.Error(err, fmt.Sprintf("listing %s for field: %s - %s", crList.GroupVersionKind().Kind, field, src.GetNamespace()))
+			return requests
 		}
 
 		for _, item := range crList.Items {


### PR DESCRIPTION
It is hidden right now if there is an error in configured named fields and index. Lets log the error and return the current state of requests.

With this the findObjectsForSrc() will exit with an hidden error like:

```
"error": "Index with name field:.spec.ksmTls.caBundleSecretName does not exist"
```