### PR TITLE
Use storagemgmt network by default if defined

### DIFF
--- a/controllers/swiftstorage_controller.go
+++ b/controllers/swiftstorage_controller.go
@@ -343,9 +343,15 @@ func (r *SwiftStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		for _, swiftPod := range podList.Items {
 			dnsIP := ""
 			if len(instance.Spec.NetworkAttachments) > 0 {
-				dnsIP, err = getPodIPInNetwork(swiftPod, instance.Namespace, "storage")
+				dnsIP, err = getPodIPInNetwork(swiftPod, instance.Namespace, "storagemgmt")
+
 				if err != nil {
-					return ctrl.Result{}, err
+					previousErr := err
+					dnsIP, err = getPodIPInNetwork(swiftPod, instance.Namespace, "storage")
+					if err != nil {
+						err = errors.Join(previousErr, err)
+						return ctrl.Result{}, err
+					}
 				}
 			}
 


### PR DESCRIPTION
Swift uses the storage network currently, but the correct network should be the storagemgmt one. This fix prefers the storagemgmt and falls back to storage to prevent failures in already deployed environments.