### PR TITLE
Fix swift-ring-files ConfigMap update issue

### DIFF
--- a/controllers/swift_controller.go
+++ b/controllers/swift_controller.go
@@ -184,7 +184,7 @@ func (r *SwiftReconciler) reconcileNormal(ctx context.Context, instance *swiftv1
 			APIGroups:     []string{""},
 			Resources:     []string{"configmaps"},
 			ResourceNames: []string{"swift-ring-files"},
-			Verbs:         []string{"get", "update"},
+			Verbs:         []string{"get", "update", "delete"},
 		},
 	}
 	rbacResult, err := common_rbac.ReconcileRbac(ctx, helper, instance, rbacRules)


### PR DESCRIPTION
If the ring file configmap is created without an owner set, updating and adding the ownerRef fails because this requires the delete verb. This happens for example when adopting an existing deployment.

Jira: [OSPRH-11016](https://issues.redhat.com//browse/OSPRH-11016)