### PR TITLE
Fix NetworkReadyCondition if using zero replicas

### DIFF
--- a/controllers/swiftproxy_controller.go
+++ b/controllers/swiftproxy_controller.go
@@ -660,7 +660,7 @@ func (r *SwiftProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 
 		instance.Status.NetworkAttachments = networkAttachmentStatus
-		if networkReady {
+		if networkReady || *instance.Spec.Replicas == 0 {
 			instance.Status.Conditions.MarkTrue(condition.NetworkAttachmentsReadyCondition, condition.NetworkAttachmentsReadyMessage)
 		} else {
 			err := fmt.Errorf("not all pods have interfaces with ips as configured in NetworkAttachments: %s", instance.Spec.NetworkAttachments)

--- a/controllers/swiftstorage_controller.go
+++ b/controllers/swiftstorage_controller.go
@@ -319,7 +319,7 @@ func (r *SwiftStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 
 		instance.Status.NetworkAttachments = networkAttachmentStatus
-		if networkReady {
+		if networkReady || *instance.Spec.Replicas == 0 {
 			instance.Status.Conditions.MarkTrue(condition.NetworkAttachmentsReadyCondition, condition.NetworkAttachmentsReadyMessage)
 		} else {
 			err := fmt.Errorf("not all pods have interfaces with ips as configured in NetworkAttachments: %s", instance.Spec.NetworkAttachments)


### PR DESCRIPTION
Zero replicas are used when adopting a dataplane, and in that case the SwiftStorage instance will never reach the Ready state because there are no pods running that can be attached to a network.

This commit fixes the condition update for the SwiftStorage and SwiftProxy instance as well.