### PR TITLE
[httpd] Set X-Forwarded-Proto only if empty

### DIFF
--- a/templates/swiftproxy/config/httpd.conf
+++ b/templates/swiftproxy/config/httpd.conf
@@ -34,7 +34,11 @@ CustomLog /dev/stdout proxy env=forwarded
 
   ## Request header rules
   ## as per http://httpd.apache.org/docs/2.2/mod/mod_headers.html#requestheader
-  RequestHeader set X-Forwarded-Proto "https"
+{{- if $vhost.TLS }}
+  RequestHeader setIfEmpty X-Forwarded-Proto "https"
+{{- else }}
+  RequestHeader setIfEmpty X-Forwarded-Proto "http"
+{{- end }}
 
   LimitRequestBody 5368709122
   LimitRequestFields 200


### PR DESCRIPTION
As done for neutron-operator [1], adding a conditional to set the header only if it is empty.
This is required in case we deploy with tls.podlevel=false and tls.ingress=true.

Jira: https://issues.redhat.com/browse/OSPRH-12375

[1] openstack-k8s-operators/neutron-operator#453