### PR TITLE
Add node-awareness to ring rebalance when using PVs

### DIFF
--- a/templates/swiftring/bin/swift-ring-tool
+++ b/templates/swiftring/bin/swift-ring-tool
@@ -72,9 +72,24 @@ done < $DEVICESFILE
 }
 
 
+function metaswap() {
+/usr/bin/env python3 << EOF
+from swift.common.ring import RingBuilder
+builder = RingBuilder.load("$1")
+for dev in builder.devs:
+    if dev.get('meta') and dev.get('device') == 'pv':
+        dev['meta'], dev['ip'] = dev['ip'], dev['meta']
+builder.save("$1")
+EOF
+}
+
+
 function rebalance() {
     for f in *.builder; do
+        metaswap $f || exit
         swift-ring-builder $f rebalance
+        metaswap $f || exit
+        swift-ring-builder $f write_ring
     done
 }
 
@@ -82,8 +97,8 @@ function rebalance() {
 function forced_rebalance() {
     for f in *.builder; do
         swift-ring-builder $f pretend_min_part_hours_passed
-        swift-ring-builder $f rebalance
     done
+    rebalance
 }
 
 
@@ -196,6 +211,10 @@ case $1 in
 
     "remove")
         remove $2
+    ;;
+
+    "metaswap")
+        metaswap $2
     ;;
 
     "rebalance")


### PR DESCRIPTION
The ring rebalance uses the hostname/IP of the device to distribute replicas across nodes. However, since there is one unique hostname per pod and multiple pods might be running on the same hardware node, this does not guarantee replica assignment to different nodes when using PVs as backend and using multiple PVs per node.

To ensure devices are distributed within the cluster as far from each other as possible, the underlying nodename needs to be used when rebalancing.

The node name of each PVs is already stored within the metadata field of the Swift ring. This change makes use of this when rebalancing: it swaps the IP and meta fields, rebalances (now using the actual node name itself and not the pod name) and afterwards swaps back meta and IP field. Afterwards write_ring is called to rewrite the .ring.gz files from the .builder files without rebalancing again.

Jira: [OSPRH-6928](https://issues.redhat.com//browse/OSPRH-6928)

Depends-On: https://github.com/openstack-k8s-operators/openstack-operator/pull/1306