### PR TITLE
Optmize handling topology logic

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/onsi/ginkgo/v2 v2.20.1
 	github.com/onsi/gomega v1.34.1
-	github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250411133346-82683c873656
+	github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250414173555-d17cbc245462
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250408123225-0d9e9b82c41b
 	k8s.io/api v0.29.15
 	k8s.io/apimachinery v0.29.15

--- a/api/go.sum
+++ b/api/go.sum
@@ -72,8 +72,8 @@ github.com/onsi/ginkgo/v2 v2.20.1 h1:YlVIbqct+ZmnEph770q9Q7NVAz4wwIiVNahee6JyUzo
 github.com/onsi/ginkgo/v2 v2.20.1/go.mod h1:lG9ey2Z29hR41WMVthyJBGUBcBhGOtoPF2VFMvBXFCI=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
-github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250411133346-82683c873656 h1:T/hODJCaWH13MV+7+snYAA1d/uuDYW0K20QDCfSSXj4=
-github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250411133346-82683c873656/go.mod h1:+l+sclC6YCRcLcvS3UEGKBf8xya8aExMrmHeA9tMg+k=
+github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250414173555-d17cbc245462 h1:hWdJM9hB/GSFjXc7E7b9L+2H4ZfCOxygceMiYXR4kKc=
+github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250414173555-d17cbc245462/go.mod h1:+l+sclC6YCRcLcvS3UEGKBf8xya8aExMrmHeA9tMg+k=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250408123225-0d9e9b82c41b h1:T+N6xOT2NP+hVp2K1xl/NV3uheVHu38CcBuW+8uOBYw=
 github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250408123225-0d9e9b82c41b/go.mod h1:A9Ohw5Q90YOGhcDF4ZHkMr5RArz3phoBu9+ibbYDKG4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/controllers/swift_common.go
+++ b/controllers/swift_common.go
@@ -66,19 +66,6 @@ type topologyHandler interface {
 	SetLastAppliedTopology(t *topologyv1.TopoRef)
 }
 
-// GetLastAppliedTopologyRef - Returns a TopoRef object that can be passed to the
-// Handle topology logic
-func GetLastAppliedTopologyRef(t topologyHandler, ns string) *topologyv1.TopoRef {
-	lastAppliedTopologyName := ""
-	if l := t.GetLastAppliedTopology(); l != nil {
-		lastAppliedTopologyName = l.Name
-	}
-	return &topologyv1.TopoRef{
-		Name:      lastAppliedTopologyName,
-		Namespace: ns,
-	}
-}
-
 func ensureTopology(
 	ctx context.Context,
 	helper *helper.Helper,
@@ -92,7 +79,7 @@ func ensureTopology(
 		ctx,
 		helper,
 		instance.GetSpecTopologyRef(),
-		GetLastAppliedTopologyRef(instance, helper.GetBefore().GetNamespace()),
+		instance.GetLastAppliedTopology(),
 		finalizer,
 		defaultLabelSelector,
 	)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.20.1
 	github.com/onsi/gomega v1.34.1
 	github.com/openstack-k8s-operators/barbican-operator/api v0.6.1-0.20250411100419-8a46bbfcee3c
-	github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250411133346-82683c873656
+	github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250414173555-d17cbc245462
 	github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250411095611-8c6f7c175271
 	github.com/openstack-k8s-operators/lib-common/modules/ansible v0.6.1-0.20250408123225-0d9e9b82c41b
 	github.com/openstack-k8s-operators/lib-common/modules/common v0.6.1-0.20250408123225-0d9e9b82c41b

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094 h1:J1wuGhVxpsHykZBa6
 github.com/openshift/api v0.0.0-20240830023148-b7d0481c9094/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
 github.com/openstack-k8s-operators/barbican-operator/api v0.6.1-0.20250411100419-8a46bbfcee3c h1:7OkeRkF2bmrZdRHspf7erdlqjyCGAT/KDeISzFRS9oA=
 github.com/openstack-k8s-operators/barbican-operator/api v0.6.1-0.20250411100419-8a46bbfcee3c/go.mod h1:dKcwSMktw5/wsbibmV1AkHATGIN9ErAdNOV6peK6eEY=
-github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250411133346-82683c873656 h1:T/hODJCaWH13MV+7+snYAA1d/uuDYW0K20QDCfSSXj4=
-github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250411133346-82683c873656/go.mod h1:+l+sclC6YCRcLcvS3UEGKBf8xya8aExMrmHeA9tMg+k=
+github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250414173555-d17cbc245462 h1:hWdJM9hB/GSFjXc7E7b9L+2H4ZfCOxygceMiYXR4kKc=
+github.com/openstack-k8s-operators/infra-operator/apis v0.6.1-0.20250414173555-d17cbc245462/go.mod h1:+l+sclC6YCRcLcvS3UEGKBf8xya8aExMrmHeA9tMg+k=
 github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250411095611-8c6f7c175271 h1:bxylJDALqTTCNg5L7aRcp4w9YwSGbEDLDfESh1Nwn14=
 github.com/openstack-k8s-operators/keystone-operator/api v0.6.1-0.20250411095611-8c6f7c175271/go.mod h1:kn18hOc8aogrUa0lbxmv52KCYLqSOI3p/aDQePUPIqw=
 github.com/openstack-k8s-operators/lib-common/modules/ansible v0.6.1-0.20250408123225-0d9e9b82c41b h1:2xnk/HpW6qbT4GM0uZwIEOOL1ZZ6uoxdjdG77fK519w=


### PR DESCRIPTION
This patch removes the need of using `GetLastAppliedTopologyRef` to build a `topologyRef` used by `EnsureServiceTopology` provided by infra-operator. In particular, we can now blindly pass `instance.Status.LastAppliedTopologyRef`, and checking that is not nil is deferred to the infra-operator logic [1]. This change also allows to deduplicate most of the common code present in all operators.

Depends-On: https://github.com/openstack-k8s-operators/infra-operator/pull/367
Jira: https://issues.redhat.com/browse/OSPRH-15412

[1] https://github.com/openstack-k8s-operators/infra-operator/pull/367