### PR TITLE
Do not update status when reconciler exits due to panic

### DIFF
--- a/controllers/swift_controller.go
+++ b/controllers/swift_controller.go
@@ -113,6 +113,11 @@ func (r *SwiftReconciler) Reconcile(ctx context.Context, req ctrl.Request) (resu
 	// Always patch the instance status when exiting this function so we can
 	// persist any changes.
 	defer func() {
+		// Don't update the status, if Reconciler Panics
+		if rc := recover(); rc != nil {
+			r.Log.Info(fmt.Sprintf("Panic during reconcile %v\n", rc))
+			panic(rc)
+		}
 		condition.RestoreLastTransitionTimes(
 			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {

--- a/controllers/swiftproxy_controller.go
+++ b/controllers/swiftproxy_controller.go
@@ -137,6 +137,11 @@ func (r *SwiftProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// Always patch the instance status when exiting this function so we can
 	// persist any changes.
 	defer func() {
+		// Don't update the status, if Reconciler Panics
+		if rc := recover(); rc != nil {
+			r.Log.Info(fmt.Sprintf("Panic during reconcile %v\n", rc))
+			panic(rc)
+		}
 		condition.RestoreLastTransitionTimes(
 			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {

--- a/controllers/swiftring_controller.go
+++ b/controllers/swiftring_controller.go
@@ -116,6 +116,11 @@ func (r *SwiftRingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Always patch the instance status when exiting this function so we can
 	// persist any changes.
 	defer func() {
+		// Don't update the status, if Reconciler Panics
+		if rc := recover(); rc != nil {
+			r.Log.Info(fmt.Sprintf("Panic during reconcile %v\n", rc))
+			panic(rc)
+		}
 		condition.RestoreLastTransitionTimes(
 			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {

--- a/controllers/swiftstorage_controller.go
+++ b/controllers/swiftstorage_controller.go
@@ -149,6 +149,11 @@ func (r *SwiftStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Always patch the instance status when exiting this function so we can
 	// persist any changes.
 	defer func() {
+		// Don't update the status, if Reconciler Panics
+		if rc := recover(); rc != nil {
+			r.Log.Info(fmt.Sprintf("Panic during reconcile %v\n", rc))
+			panic(rc)
+		}
 		condition.RestoreLastTransitionTimes(
 			&instance.Status.Conditions, savedConditions)
 		if instance.Status.Conditions.IsUnknown(condition.ReadyCondition) {


### PR DESCRIPTION
Currently we use deferred call to always update the status field when Reconcile call exits, which seems correct for any other error except Reconciler exits due to panic.

This change adds a call to recover function and try to handle panic and log error.

Closes: [OSPRH-16938](https://issues.redhat.com//browse/OSPRH-16938)