### PR TITLE
Add MTLS certificates and enable mtls auth

### DIFF
--- a/controllers/swiftproxy_controller.go
+++ b/controllers/swiftproxy_controller.go
@@ -654,7 +654,7 @@ func (r *SwiftProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	// Create Deployment
-	ssDef, err := swiftproxy.Deployment(instance, serviceLabels, serviceAnnotations, inputHash, topology)
+	ssDef, err := swiftproxy.Deployment(instance, serviceLabels, serviceAnnotations, inputHash, topology, memcached)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			swiftv1beta1.SwiftProxyReadyCondition,

--- a/pkg/swiftproxy/templates.go
+++ b/pkg/swiftproxy/templates.go
@@ -51,6 +51,17 @@ func SecretTemplates(
 	templateParameters["KeystoneRegion"] = keystoneRegion
 	templateParameters["TransportURL"] = transportURL
 
+	// MTLS params
+	if mc.Status.MTLSCert != "" {
+		templateParameters["MemcachedAuthCert"] = fmt.Sprint(memcachedv1.CertMountPath())
+		templateParameters["MemcachedAuthKey"] = fmt.Sprint(memcachedv1.KeyMountPath())
+		templateParameters["MemcachedAuthCa"] = fmt.Sprint(memcachedv1.CaMountPath())
+	} else {
+		templateParameters["MemcachedAuthCert"] = ""
+		templateParameters["MemcachedAuthKey"] = ""
+		templateParameters["MemcachedAuthCa"] = ""
+	}
+
 	// create httpd  vhost template parameters
 	httpdVhostConfig := map[string]interface{}{}
 	for _, endpt := range []service.Endpoint{service.EndpointInternal, service.EndpointPublic} {

--- a/templates/swiftproxy/config/00-proxy-server.conf
+++ b/templates/swiftproxy/config/00-proxy-server.conf
@@ -16,6 +16,11 @@ use = egg:swift#healthcheck
 use = egg:swift#memcache
 memcache_servers = {{ .MemcachedServers }}
 tls_enabled = {{ .MemcachedTLS }}
+{{if .MemcachedAuthCert}}
+tls_certfile={{ .MemcachedAuthCert }}
+tls_keyfile={{ .MemcachedAuthKey }}
+tls_cafile={{ .MemcachedAuthCa }}
+{{end}}
 
 [filter:ratelimit]
 use = egg:swift#ratelimit


### PR DESCRIPTION
This change adds additional volume/volumemounts if memcached has been configured for MTLS auth, and adds the necessary parameters for the swift cache middleware to set the tls context.