### PR TITLE
Add option to disable ring init/rebalance job

### DIFF
--- a/api/bases/swift.openstack.org_swiftrings.yaml
+++ b/api/bases/swift.openstack.org_swiftrings.yaml
@@ -51,6 +51,11 @@ spec:
               containerImage:
                 description: Image URL for Swift proxy service
                 type: string
+              enabled:
+                default: true
+                description: Enabled - Whether SwiftRing service should be deployed
+                  and managed
+                type: boolean
               minPartHours:
                 default: 1
                 description: Minimum number of hours to restrict moving a partition

--- a/api/bases/swift.openstack.org_swifts.yaml
+++ b/api/bases/swift.openstack.org_swifts.yaml
@@ -368,6 +368,11 @@ spec:
                   containerImage:
                     description: Image URL for Swift proxy service
                     type: string
+                  enabled:
+                    default: true
+                    description: Enabled - Whether SwiftRing service should be deployed
+                      and managed
+                    type: boolean
                   minPartHours:
                     default: 1
                     description: Minimum number of hours to restrict moving a partition

--- a/api/v1beta1/swiftring_types.go
+++ b/api/v1beta1/swiftring_types.go
@@ -44,6 +44,11 @@ type SwiftRingSpec struct {
 
 // SwiftRingSpec defines the desired state of SwiftRing
 type SwiftRingSpecCore struct {
+    // +kubebuilder:validation:Optional
+    // Enabled - Whether SwiftRing service should be deployed and managed
+    // +kubebuilder:default=true
+    // +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"}
+    Enabled bool `json:"enabled"`
 
 	// +kubebuilder:validation:Required
 	// +kubebuilder:default=1

--- a/config/crd/bases/swift.openstack.org_swiftrings.yaml
+++ b/config/crd/bases/swift.openstack.org_swiftrings.yaml
@@ -51,6 +51,11 @@ spec:
               containerImage:
                 description: Image URL for Swift proxy service
                 type: string
+              enabled:
+                default: true
+                description: Enabled - Whether SwiftRing service should be deployed
+                  and managed
+                type: boolean
               minPartHours:
                 default: 1
                 description: Minimum number of hours to restrict moving a partition

--- a/config/crd/bases/swift.openstack.org_swifts.yaml
+++ b/config/crd/bases/swift.openstack.org_swifts.yaml
@@ -368,6 +368,11 @@ spec:
                   containerImage:
                     description: Image URL for Swift proxy service
                     type: string
+                  enabled:
+                    default: true
+                    description: Enabled - Whether SwiftRing service should be deployed
+                      and managed
+                    type: boolean
                   minPartHours:
                     default: 1
                     description: Minimum number of hours to restrict moving a partition

--- a/hack/crd-schema-checker.sh
+++ b/hack/crd-schema-checker.sh
@@ -3,6 +3,16 @@ set -euxo pipefail
 
 CHECKER=$INSTALL_DIR/crd-schema-checker
 
+DISABLED_VALIDATORS=NoMaps,NoBools,ListsMustHaveSSATags # TODO: https://issues.redhat.com/browse/OSPRH-12254
+
+CHECKER_ARGS=""
+if [[ ${DISABLED_VALIDATORS:+x} ]]; then
+    CHECKER_ARGS="$CHECKER_ARGS "
+    for check in ${DISABLED_VALIDATORS//,/ }; do
+        CHECKER_ARGS+=" --disabled-validators $check"
+    done
+fi
+
 TMP_DIR=$(mktemp -d)
 
 function cleanup {
@@ -16,6 +26,7 @@ for crd in config/crd/bases/*.yaml; do
     mkdir -p "$(dirname "$TMP_DIR/$crd")"
     if git show "$BASE_REF:$crd" > "$TMP_DIR/$crd"; then
         $CHECKER check-manifests \
+            $CHECKER_ARGS \
             --existing-crd-filename="$TMP_DIR/$crd" \
             --new-crd-filename="$crd"
     fi


### PR DESCRIPTION
This makes it possible to disable automatic ring management if needed. Depending on the cluster this might be needed, for example when using storage policies or operating large clusters that are managed manually.

JIRA: [OSPRH-11686](https://issues.redhat.com//browse/OSPRH-11686)