### PR TITLE
Add configurable API Timeouts

### DIFF
--- a/api/bases/swift.openstack.org_swiftproxies.yaml
+++ b/api/bases/swift.openstack.org_swiftproxies.yaml
@@ -52,6 +52,12 @@ spec:
           spec:
             description: SwiftProxySpec defines the desired state of SwiftProxy
             properties:
+              apiTimeout:
+                default: 60
+                description: Default APITimeout for HAProxy and Apache, defaults to
+                  60 seconds
+                minimum: 1
+                type: integer
               ceilometerEnabled:
                 default: false
                 description: Enables ceilometer in the swift proxy and creates required

--- a/api/bases/swift.openstack.org_swifts.yaml
+++ b/api/bases/swift.openstack.org_swifts.yaml
@@ -86,6 +86,12 @@ spec:
                 description: SwiftProxy - Spec definition for the Proxy service of
                   this Swift deployment
                 properties:
+                  apiTimeout:
+                    default: 60
+                    description: Default APITimeout for HAProxy and Apache, defaults
+                      to 60 seconds
+                    minimum: 1
+                    type: integer
                   ceilometerEnabled:
                     default: false
                     description: Enables ceilometer in the swift proxy and creates

--- a/api/v1beta1/swift_types.go
+++ b/api/v1beta1/swift_types.go
@@ -29,6 +29,9 @@ const (
 	ContainerImageContainer = "quay.io/podified-antelope-centos9/openstack-swift-container:current-podified"
 	ContainerImageObject    = "quay.io/podified-antelope-centos9/openstack-swift-object:current-podified"
 	ContainerImageProxy     = "quay.io/podified-antelope-centos9/openstack-swift-proxy-server:current-podified"
+
+	// ProxyAPITimeoutDefault  - Default timeout in seconds for HAProxy and Apache
+	ProxyAPITimeout = 60
 )
 
 // SwiftSpec defines the desired state of Swift

--- a/api/v1beta1/swiftproxy_types.go
+++ b/api/v1beta1/swiftproxy_types.go
@@ -113,6 +113,11 @@ type SwiftProxySpecCore struct {
 	// by name
 	TopologyRef *topologyv1.TopoRef `json:"topologyRef,omitempty"`
 
+	// +kubebuilder:default=60
+	// +kubebuilder:validation:Minimum=1
+	// Default APITimeout for HAProxy and Apache, defaults to 60 seconds
+	APITimeout int `json:"apiTimeout,omitempty"`
+
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default={swift-ring-files}
 	// +listType=atomic

--- a/config/crd/bases/swift.openstack.org_swiftproxies.yaml
+++ b/config/crd/bases/swift.openstack.org_swiftproxies.yaml
@@ -52,6 +52,12 @@ spec:
           spec:
             description: SwiftProxySpec defines the desired state of SwiftProxy
             properties:
+              apiTimeout:
+                default: 60
+                description: Default APITimeout for HAProxy and Apache, defaults to
+                  60 seconds
+                minimum: 1
+                type: integer
               ceilometerEnabled:
                 default: false
                 description: Enables ceilometer in the swift proxy and creates required

--- a/config/crd/bases/swift.openstack.org_swifts.yaml
+++ b/config/crd/bases/swift.openstack.org_swifts.yaml
@@ -86,6 +86,12 @@ spec:
                 description: SwiftProxy - Spec definition for the Proxy service of
                   this Swift deployment
                 properties:
+                  apiTimeout:
+                    default: 60
+                    description: Default APITimeout for HAProxy and Apache, defaults
+                      to 60 seconds
+                    minimum: 1
+                    type: integer
                   ceilometerEnabled:
                     default: false
                     description: Enables ceilometer in the swift proxy and creates

--- a/controllers/swiftproxy_controller.go
+++ b/controllers/swiftproxy_controller.go
@@ -582,6 +582,7 @@ func (r *SwiftProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		secretRef,
 		os.GetRegion(),
 		transportURLString,
+		instance.Spec.APITimeout,
 	)
 	err = secret.EnsureSecrets(ctx, helper, instance, tpl, &envVars)
 	if err != nil {

--- a/pkg/swiftproxy/templates.go
+++ b/pkg/swiftproxy/templates.go
@@ -38,6 +38,7 @@ func SecretTemplates(
 	secretRef string,
 	keystoneRegion string,
 	transportURL string,
+	apiTimeout int,
 ) []util.Template {
 	templateParameters := make(map[string]interface{})
 	templateParameters["ServiceUser"] = instance.Spec.ServiceUser
@@ -50,6 +51,7 @@ func SecretTemplates(
 	templateParameters["SecretRef"] = secretRef
 	templateParameters["KeystoneRegion"] = keystoneRegion
 	templateParameters["TransportURL"] = transportURL
+	templateParameters["APITimeout"] = apiTimeout
 
 	// MTLS params
 	if mc.Status.MTLSCert != "" {

--- a/templates/swiftproxy/config/httpd.conf
+++ b/templates/swiftproxy/config/httpd.conf
@@ -22,6 +22,8 @@ SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
 CustomLog /dev/stdout combined env=!forwarded
 CustomLog /dev/stdout proxy env=forwarded
 
+TimeOut {{ .APITimeout }}
+
 {{ range $endpt, $vhost := .VHosts }}
 # {{ $endpt }} vhost {{ $vhost.ServerName }} configuration
 <VirtualHost *:8080>


### PR DESCRIPTION
This patch adds an `apiTimeout` field to the `SwiftProxySpecCore` to allow human operators to simultaneously configure the timeouts for HAProxy and Apache. The `apiTimeout` defaults to 60 seconds to mimic the behavior present in OSP17.

Jira: https://issues.redhat.com/browse/OSPRH-10957