### PR TITLE
Modernize Go code with latest style conventions

### DIFF
--- a/controllers/swift_common.go
+++ b/controllers/swift_common.go
@@ -59,7 +59,7 @@ var (
 
 type conditionUpdater interface {
 	Set(c *condition.Condition)
-	MarkTrue(t condition.Type, messageFormat string, messageArgs ...interface{})
+	MarkTrue(t condition.Type, messageFormat string, messageArgs ...any)
 }
 
 type topologyHandler interface {

--- a/pkg/swift/funcs.go
+++ b/pkg/swift/funcs.go
@@ -58,7 +58,7 @@ func RandomString(length int) string {
 	sample := "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	str := make([]byte, length)
 
-	for i := 0; i < length; i++ {
+	for i := range length {
 		str[i] = sample[rand.Intn(len(sample))] //nolint:gosec // G404: Non-cryptographic use acceptable for Swift hash generation
 	}
 	return string(str)

--- a/pkg/swift/templates.go
+++ b/pkg/swift/templates.go
@@ -23,7 +23,7 @@ import (
 
 // SecretTemplates creates secret templates for swift configuration
 func SecretTemplates(instance *swiftv1beta1.Swift, serviceLabels map[string]string) []util.Template {
-	templateParameters := make(map[string]interface{})
+	templateParameters := make(map[string]any)
 	templateParameters["SwiftHashPathPrefix"] = RandomString(16)
 	templateParameters["SwiftHashPathSuffix"] = RandomString(16)
 

--- a/pkg/swiftring/funcs.go
+++ b/pkg/swiftring/funcs.go
@@ -107,7 +107,7 @@ func DeviceList(ctx context.Context, h *helper.Helper, instance *swiftv1beta1.Sw
 		}
 		nodeSetGroup := inventory.Groups[secret.Labels["openstackdataplanenodeset"]]
 
-		if slices.Contains(nodeSetGroup.Vars["edpm_services"].([]interface{}), "swift") {
+		if slices.Contains(nodeSetGroup.Vars["edpm_services"].([]any), "swift") {
 			// Get the global disk vars first that are used for all
 			// nodes if not set otherwise per-node
 			var globalDisks []swiftv1beta1.SwiftDisk

--- a/pkg/swiftstorage/templates.go
+++ b/pkg/swiftstorage/templates.go
@@ -18,6 +18,7 @@ package swiftstorage
 
 import (
 	"fmt"
+	"maps"
 
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
@@ -29,15 +30,13 @@ func ConfigMapTemplates(instance *swiftv1beta1.SwiftStorage,
 	labels map[string]string,
 	mc *memcachedv1.Memcached,
 	bindIP string) []util.Template {
-	templateParameters := make(map[string]interface{})
+	templateParameters := make(map[string]any)
 	templateParameters["MemcachedServers"] = mc.GetMemcachedServerListString()
 	templateParameters["MemcachedTLS"] = mc.GetMemcachedTLSSupport()
 	templateParameters["BindIP"] = bindIP
 
 	customData := map[string]string{}
-	for key, data := range instance.Spec.DefaultConfigOverwrite {
-		customData[key] = data
-	}
+	maps.Copy(customData, instance.Spec.DefaultConfigOverwrite)
 
 	return []util.Template{
 		{


### PR DESCRIPTION
Applied automated modernization using gopls modernize tool to update:
- Replace interface{} with any type alias (Go 1.18+)
- Update range loops to use idiomatic range syntax
- Replace fmt.Sprintf with fmt.Appendf where appropriate

These changes improve code readability and align with current Go best practices.