### PR TITLE
Fix missing memcache certificates

### DIFF
--- a/internal/controller/swiftstorage_controller.go
+++ b/internal/controller/swiftstorage_controller.go
@@ -349,7 +349,7 @@ func (r *SwiftStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Statefulset with all backend containers
-	sspec, err := swiftstorage.StatefulSet(instance, serviceLabels, serviceAnnotations, inputHash, topology)
+	sspec, err := swiftstorage.StatefulSet(instance, serviceLabels, serviceAnnotations, inputHash, topology, memcached)
 	if err != nil {
 		instance.Status.Conditions.Set(condition.FalseCondition(
 			swiftv1beta1.SwiftStorageReadyCondition,

--- a/internal/swiftstorage/templates.go
+++ b/internal/swiftstorage/templates.go
@@ -35,6 +35,17 @@ func ConfigMapTemplates(instance *swiftv1beta1.SwiftStorage,
 	templateParameters["MemcachedTLS"] = mc.GetMemcachedTLSSupport()
 	templateParameters["BindIP"] = bindIP
 
+	// MTLS params
+	if mc.Status.MTLSCert != "" {
+		templateParameters["MemcachedAuthCert"] = fmt.Sprint(memcachedv1.CertMountPath())
+		templateParameters["MemcachedAuthKey"] = fmt.Sprint(memcachedv1.KeyMountPath())
+		templateParameters["MemcachedAuthCa"] = fmt.Sprint(memcachedv1.CaMountPath())
+	} else {
+		templateParameters["MemcachedAuthCert"] = ""
+		templateParameters["MemcachedAuthKey"] = ""
+		templateParameters["MemcachedAuthCa"] = ""
+	}
+
 	customData := map[string]string{}
 	maps.Copy(customData, instance.Spec.DefaultConfigOverwrite)
 

--- a/templates/swiftstorage/config/00-object-expirer.conf
+++ b/templates/swiftstorage/config/00-object-expirer.conf
@@ -14,6 +14,11 @@ use = egg:swift#proxy
 use = egg:swift#memcache
 memcache_servers = {{ .MemcachedServers }}
 tls_enabled = {{ .MemcachedTLS }}
+{{if .MemcachedAuthCert}}
+tls_certfile={{ .MemcachedAuthCert }}
+tls_keyfile={{ .MemcachedAuthKey }}
+tls_cafile={{ .MemcachedAuthCa }}
+{{end}}
 
 [filter:catch_errors]
 use = egg:swift#catch_errors

--- a/templates/swiftstorage/config/internal-client.conf
+++ b/templates/swiftstorage/config/internal-client.conf
@@ -12,6 +12,13 @@ use = egg:swift#symlink
 
 [filter:cache]
 use = egg:swift#memcache
+memcache_servers = {{ .MemcachedServers }}
+tls_enabled = {{ .MemcachedTLS }}
+{{if .MemcachedAuthCert}}
+tls_certfile={{ .MemcachedAuthCert }}
+tls_keyfile={{ .MemcachedAuthKey }}
+tls_cafile={{ .MemcachedAuthCa }}
+{{end}}
 
 [filter:proxy-logging]
 use = egg:swift#proxy_logging


### PR DESCRIPTION
memcache certificates are not configured and missing for the object-expirer service as well as the internal-client.

JIRA: [OSPRH-23072](https://issues.redhat.com//browse/OSPRH-23072)