### PR TITLE
Enforce kuttl deployment cleanup

### DIFF
--- a/test/kuttl/tests/basic-deploy/03-cleanup.yaml
+++ b/test/kuttl/tests/basic-deploy/03-cleanup.yaml
@@ -1,10 +1,8 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-- apiVersion: swift.openstack.org/v1beta1
-  kind: Swift
-  name: swift
 commands:
+- script: |
+    oc delete --wait=true -n $NAMESPACE -f ../../../../config/samples/swift_v1beta1_swift.yaml
 - script: |
     oc delete --ignore-not-found=true -n $NAMESPACE pvc swift-swift-storage-0
     oc delete --ignore-not-found=true -n $NAMESPACE pvc swift-swift-storage-1

--- a/test/kuttl/tests/basic-deploy_tls/02-cleanup.yaml
+++ b/test/kuttl/tests/basic-deploy_tls/02-cleanup.yaml
@@ -1,10 +1,8 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-- apiVersion: swift.openstack.org/v1beta1
-  kind: Swift
-  name: swift
 commands:
+- script: |
+    oc delete --wait=true -n $NAMESPACE -f ../../../../config/samples/swift_v1beta1_swift_tls.yaml
 - script: |
     oc delete --ignore-not-found=true -n $NAMESPACE pvc swift-swift-storage-0
     for pv in $(oc get pv | grep "Released.*swift" | cut -f 1 -d " "); do oc patch pv $pv -p '{"spec":{"claimRef": null}}'; done

--- a/test/kuttl/tests/customization/03-assert-ceilometer.yaml
+++ b/test/kuttl/tests/customization/03-assert-ceilometer.yaml
@@ -3,4 +3,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - script: |
-      oc -n $NAMESPACE rsh rabbitmq-server-0 /bin/sh -c "rabbitmqadmin get queue=notifications.info" | grep swift
+      oc -n $NAMESPACE rsh -c rabbitmq rabbitmq-server-0 /bin/sh -c "rabbitmqctl list_exchanges -p / name" | grep swift

--- a/test/kuttl/tests/customization/09-cleanup.yaml
+++ b/test/kuttl/tests/customization/09-cleanup.yaml
@@ -1,10 +1,8 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-- apiVersion: swift.openstack.org/v1beta1
-  kind: Swift
-  name: swift
 commands:
+- script: |
+    oc kustomize deploy | oc delete --wait=true -n $NAMESPACE -f -
 - script: |
     oc delete --ignore-not-found=true -n $NAMESPACE secret swift-conf
     oc delete --ignore-not-found=true -n $NAMESPACE pvc swift-swift-storage-0

--- a/test/kuttl/tests/replication/04-cleanup.yaml
+++ b/test/kuttl/tests/replication/04-cleanup.yaml
@@ -1,10 +1,8 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
-delete:
-- apiVersion: swift.openstack.org/v1beta1
-  kind: Swift
-  name: swift
 commands:
+- script: |
+    oc kustomize deploy | oc delete --wait=true -n $NAMESPACE -f -
 - script: |
     oc delete --ignore-not-found=true -n $NAMESPACE pvc swift-swift-storage-0
     oc delete --ignore-not-found=true -n $NAMESPACE pvc swift-swift-storage-1


### PR DESCRIPTION
Uses the same command that was used to deploy the test environment at the end of each test. Lingering deployments will affect all following tests otherwise.