### PR TITLE
[b/r] Add backup/restore labels for PVCs, swift-conf Secret, and ring ConfigMap

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -29,6 +29,15 @@ rules:
   - ""
   resources:
   - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/internal/controller/swift_controller.go
+++ b/internal/controller/swift_controller.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	memcachedv1 "github.com/openstack-k8s-operators/infra-operator/apis/memcached/v1beta1"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/backup"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/helper"
@@ -66,6 +67,7 @@ func (r *SwiftReconciler) GetLogger(ctx context.Context) logr.Logger {
 // +kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=get;list;watch;create;update;patch
 // service account permissions that are needed to grant permission to the above
 // +kubebuilder:rbac:groups="security.openshift.io",resourceNames=nonroot-v2,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -237,6 +239,11 @@ func (r *SwiftReconciler) reconcileNormal(ctx context.Context, instance *swiftv1
 	}
 
 	instance.Status.Conditions.MarkTrue(condition.ServiceConfigReadyCondition, condition.ServiceConfigReadyMessage)
+
+	// Ensure backup labels on the swift-conf Secret for existing environments
+	if err := r.reconcileSwiftConfLabels(ctx, instance); err != nil {
+		return ctrl.Result{}, err
+	}
 
 	//
 	// Check for required memcached used for caching
@@ -411,6 +418,28 @@ func (r *SwiftReconciler) reconcileNormal(ctx context.Context, instance *swiftv1
 	}
 	Log.Info(fmt.Sprintf("Reconciled Service '%s' successfully", instance.Name))
 	return ctrl.Result{}, nil
+}
+
+// reconcileSwiftConfLabels ensures backup labels are set on the swift-conf
+// Secret for existing environments that were created before backup support.
+func (r *SwiftReconciler) reconcileSwiftConfLabels(ctx context.Context, instance *swiftv1.Swift) error {
+	swiftConfSecret := &corev1.Secret{}
+	err := r.Get(ctx, client.ObjectKey{
+		Name:      swift.SwiftConfSecretName,
+		Namespace: instance.Namespace,
+	}, swiftConfSecret)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	if _, err := backup.EnsureBackupLabels(ctx, r.Client, swiftConfSecret,
+		backup.GetRestoreLabels(backup.RestoreOrder10, backup.CategoryControlPlane)); err != nil {
+		return err
+	}
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/swiftring_controller.go
+++ b/internal/controller/swiftring_controller.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/openstack-k8s-operators/lib-common/modules/common/backup"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
@@ -243,6 +244,11 @@ func (r *SwiftRingReconciler) reconcileNormal(ctx context.Context, instance *swi
 		instance.Status.Hash[swiftv1beta1.RingCreateHash] = ringCreateJob.GetHash()
 	}
 
+	// Ensure backup labels on the ring ConfigMap for backup/restore
+	if err := r.reconcileRingConfigMapLabels(ctx, instance); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	instance.Status.Conditions.MarkTrue(condition.ReadyCondition, condition.ReadyMessage)
 	instance.Status.Conditions.MarkTrue(swiftv1beta1.SwiftRingReadyCondition, condition.ReadyMessage)
 	// Swift ring init job - end
@@ -255,6 +261,36 @@ func (r *SwiftRingReconciler) reconcileNormal(ctx context.Context, instance *swi
 	}
 	Log.Info(fmt.Sprintf("Reconciled SwiftRing '%s' successfully", instance.Name))
 	return ctrl.Result{}, nil
+}
+
+// reconcileRingConfigMapLabels ensures backup/restore labels are set on the
+// ring ConfigMap. The ring ConfigMap is created by the rebalance job (not by
+// the controller), so we reconcile labels after the job completes.
+func (r *SwiftRingReconciler) reconcileRingConfigMapLabels(
+	ctx context.Context,
+	instance *swiftv1beta1.SwiftRing,
+) error {
+	if len(instance.Spec.RingConfigMaps) == 0 {
+		return nil
+	}
+
+	ringCM := &corev1.ConfigMap{}
+	err := r.Get(ctx, client.ObjectKey{
+		Name:      instance.Spec.RingConfigMaps[0],
+		Namespace: instance.Namespace,
+	}, ringCM)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	if _, err := backup.EnsureBackupLabels(ctx, r.Client, ringCM,
+		backup.GetRestoreLabels(backup.RestoreOrder10, backup.CategoryControlPlane)); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (r *SwiftRingReconciler) reconcileDelete(ctx context.Context, instance *swiftv1beta1.SwiftRing, helper *helper.Helper) (ctrl.Result, error) {

--- a/internal/controller/swiftstorage_controller.go
+++ b/internal/controller/swiftstorage_controller.go
@@ -56,6 +56,7 @@ import (
 	"github.com/openstack-k8s-operators/swift-operator/internal/swiftstorage"
 
 	"github.com/openstack-k8s-operators/lib-common/modules/common"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/backup"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/condition"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/configmap"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/env"
@@ -90,6 +91,7 @@ type Netconfig struct {
 //+kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=memcached.openstack.org,resources=memcacheds,verbs=get;list;watch;
 //+kubebuilder:rbac:groups=network.openstack.org,resources=dnsdata,verbs=get;list;watch;create;update;patch;delete
@@ -403,6 +405,12 @@ func (r *SwiftStorageReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrlResult, nil
 	}
 
+	// Reconcile backup labels on existing PVCs that were created before
+	// backup/restore support was added
+	if err := r.reconcilePVCLabels(ctx, instance); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	deploy := sset.GetStatefulSet()
 	if deploy.Generation == deploy.Status.ObservedGeneration {
 		instance.Status.ReadyCount = deploy.Status.ReadyReplicas
@@ -624,6 +632,38 @@ func (r *SwiftStorageReconciler) createHashOfInputHashes(
 		instance.Status.Hash = hashMap
 	}
 	return hash, changed, nil
+}
+
+// reconcilePVCLabels ensures backup/restore labels are set on Swift storage PVCs.
+// StatefulSet VolumeClaimTemplates are immutable, so for existing environments
+// we reconcile PVC labels directly.
+func (r *SwiftStorageReconciler) reconcilePVCLabels(
+	ctx context.Context,
+	instance *swiftv1beta1.SwiftStorage,
+) error {
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(instance.Namespace),
+		client.MatchingLabels{
+			common.AppSelector:       swift.ServiceName,
+			common.ComponentSelector: swiftstorage.ComponentName,
+		},
+	}
+	if err := r.List(ctx, pvcList, listOpts...); err != nil {
+		return fmt.Errorf("listing PVCs for %s: %w", instance.Name, err)
+	}
+
+	for i := range pvcList.Items {
+		if _, err := backup.EnsureBackupLabels(ctx, r.Client, &pvcList.Items[i],
+			util.MergeMaps(
+				backup.GetBackupLabels(backup.CategoryControlPlane),
+				backup.GetRestoreLabels(backup.RestoreOrder00, backup.CategoryControlPlane),
+			)); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func getPodIPInNetwork(swiftPod corev1.Pod, namespace string, networkAttachment string) (string, error) {

--- a/internal/swift/templates.go
+++ b/internal/swift/templates.go
@@ -17,6 +17,7 @@ limitations under the License.
 package swift
 
 import (
+	"github.com/openstack-k8s-operators/lib-common/modules/common/backup"
 	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	swiftv1beta1 "github.com/openstack-k8s-operators/swift-operator/api/v1beta1"
 )
@@ -26,6 +27,15 @@ func SecretTemplates(instance *swiftv1beta1.Swift, serviceLabels map[string]stri
 	templateParameters := make(map[string]any)
 	templateParameters["SwiftHashPathPrefix"] = RandomString(16)
 	templateParameters["SwiftHashPathSuffix"] = RandomString(16)
+
+	// Add backup labels so the swift-conf Secret is included in backups.
+	// This Secret contains swift_hash_path_prefix/suffix which cannot be
+	// regenerated — without it Swift cannot locate existing objects.
+	serviceLabels = util.MergeStringMaps(
+		serviceLabels,
+		backup.GetBackupLabels(backup.CategoryControlPlane),
+		backup.GetRestoreLabels(backup.RestoreOrder10, backup.CategoryControlPlane),
+	)
 
 	return []util.Template{
 		{

--- a/internal/swiftstorage/statefulset.go
+++ b/internal/swiftstorage/statefulset.go
@@ -25,7 +25,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
+	"github.com/openstack-k8s-operators/lib-common/modules/common/backup"
 	env "github.com/openstack-k8s-operators/lib-common/modules/common/env"
+	"github.com/openstack-k8s-operators/lib-common/modules/common/util"
 	swiftv1beta1 "github.com/openstack-k8s-operators/swift-operator/api/v1beta1"
 	"github.com/openstack-k8s-operators/swift-operator/internal/swift"
 )
@@ -264,6 +266,10 @@ func StatefulSet(
 			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: swift.ClaimName,
+					Labels: util.MergeStringMaps(
+						backup.GetBackupLabels(backup.CategoryControlPlane),
+						backup.GetRestoreLabels(backup.RestoreOrder00, backup.CategoryControlPlane),
+					),
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
 					StorageClassName: &swiftstorage.Spec.StorageClass,


### PR DESCRIPTION
Add backup/restore labels to Swift resources so they are included in backup and can be restored in the correct order:

- Object storage PVCs: labels on VolumeClaimTemplate (new envs) + reconcilePVCLabels for existing PVCs. Restore order 00.
- swift-conf Secret: labels at creation via SecretTemplates + reconcileSwiftConfLabels for existing envs. Restore order 10. This Secret contains swift_hash_path_prefix/suffix which cannot be regenerated without losing access to existing objects.
- Ring ConfigMap (swift-ring-files): reconcileRingConfigMapLabels after rebalance job completes. Restore order 10.

Shared ensureBackupLabels helper in swift_common.go uses MergeFrom patch to avoid conflicts with concurrent updates.

Jira: [OSPRH-22912](https://redhat.atlassian.net/browse/OSPRH-22912)
Jira: [OSPRH-22913](https://redhat.atlassian.net/browse/OSPRH-22913)
Jira: [OSPRH-27012](https://redhat.atlassian.net/browse/OSPRH-27012)

Depends-On: https://github.com/openstack-k8s-operators/lib-common/pull/680