### PR TITLE
Change default MinPartHours from 1 to 24

### DIFF
--- a/api/bases/swift.openstack.org_swiftrings.yaml
+++ b/api/bases/swift.openstack.org_swiftrings.yaml
@@ -57,7 +57,7 @@ spec:
                   and managed
                 type: boolean
               minPartHours:
-                default: 1
+                default: 24
                 description: Minimum number of hours to restrict moving a partition
                   more than once
                 format: int64

--- a/api/bases/swift.openstack.org_swifts.yaml
+++ b/api/bases/swift.openstack.org_swifts.yaml
@@ -481,7 +481,7 @@ spec:
                       and managed
                     type: boolean
                   minPartHours:
-                    default: 1
+                    default: 24
                     description: Minimum number of hours to restrict moving a partition
                       more than once
                     format: int64

--- a/api/v1beta1/swiftring_types.go
+++ b/api/v1beta1/swiftring_types.go
@@ -63,7 +63,7 @@ type SwiftRingSpecCore struct {
 	PartPower *int64 `json:"partPower"`
 
 	// +kubebuilder:validation:Required
-	// +kubebuilder:default=1
+	// +kubebuilder:default=24
 	// +kubebuilder:validation:Minimum=1
 	// Minimum number of hours to restrict moving a partition more than once
 	MinPartHours *int64 `json:"minPartHours"`

--- a/config/crd/bases/swift.openstack.org_swiftrings.yaml
+++ b/config/crd/bases/swift.openstack.org_swiftrings.yaml
@@ -57,7 +57,7 @@ spec:
                   and managed
                 type: boolean
               minPartHours:
-                default: 1
+                default: 24
                 description: Minimum number of hours to restrict moving a partition
                   more than once
                 format: int64

--- a/config/crd/bases/swift.openstack.org_swifts.yaml
+++ b/config/crd/bases/swift.openstack.org_swifts.yaml
@@ -481,7 +481,7 @@ spec:
                       and managed
                     type: boolean
                   minPartHours:
-                    default: 1
+                    default: 24
                     description: Minimum number of hours to restrict moving a partition
                       more than once
                     format: int64


### PR DESCRIPTION
A min_part_hours value of 1 allows ring rebalances to move partitions almost immediately, which risks data movement before replication completes. Setting the default to 24 hours matches the upstream recommendation and gives the replicators more time to finish copying data after a rebalance.