### PR TITLE
Log OpenStack request ID in Swift proxy access logs

### DIFF
--- a/templates/swiftproxy/config/00-proxy-server.conf
+++ b/templates/swiftproxy/config/00-proxy-server.conf
@@ -36,6 +36,8 @@ use = egg:swift#formpost
 
 [filter:proxy-logging]
 use = egg:swift#proxy_logging
+access_log_headers = true
+access_log_headers_only = X-OpenStack-Request-Id
 
 [filter:bulk]
 use = egg:swift#bulk


### PR DESCRIPTION
Enable access_log_headers in the proxy-logging filter, restricted to X-OpenStack-Request-Id only. This allows tracing requests across OpenStack services in the Swift proxy access logs.