### PR TITLE
Use OpenStack CR operatorOverrides to scale down swift operator

### DIFF
--- a/hack/run_with_local_webhook.sh
+++ b/hack/run_with_local_webhook.sh
@@ -120,16 +120,14 @@ if [ -n "${CSV_NAME}" ]; then
     oc patch "${CSV_NAME}" -n openstack-operators --type=json -p="[{'op': 'replace', 'path': '/spec/install/spec/deployments/0/spec/replicas', 'value': 0}]"
     oc patch "${CSV_NAME}" -n openstack-operators --type=json -p="[{'op': 'replace', 'path': '/spec/webhookdefinitions', 'value': []}]"
 else
-    # Handle operator deployed by Openstack Initialization resource
-    CSV_NAME="$(oc get csv -n openstack-operators -l operators.coreos.com/openstack-operator.openstack-operators -o name)"
+    if CR_NAME=$(oc get openstack -n openstack-operators -o name); then
+        printf \
+        "\n\tNow patching openstack CR to scale down deployment resource.
+        To restore it, use:
+        oc patch ${CR_NAME} -n openstack-operators --type=merge -p '{\"spec\": {\"operatorOverrides\": [{\"name\": \"swift\", \"replicas\": 1}]}}'\n"
 
-    printf \
-    "\n\tNow patching openstack operator CSV to scale down deployment resource.
-    To restore it, use:
-    oc patch "${CSV_NAME}" -n openstack-operators --type=json -p=\"[{'op': 'replace', 'path': '/spec/install/spec/deployments/0/spec/replicas', 'value': 1}]\""
-
-    oc patch "${CSV_NAME}" -n openstack-operators --type=json -p="[{'op': 'replace', 'path': '/spec/install/spec/deployments/0/spec/replicas', 'value': 0}]"
-    oc scale --replicas=0 -n openstack-operators deploy/swift-operator-controller-manager
+        oc patch ${CR_NAME} -n openstack-operators --type=merge -p '{"spec": {"operatorOverrides": [{"name": "swift", "replicas": 0}]}}'
+    fi
 fi
 
 go run ./cmd/main.go -metrics-bind-address ":${METRICS_PORT}" -health-probe-bind-address ":${HEALTH_PORT}" -pprof-bind-address ":${PPROF_PORT}" -webhook-bind-address "${WEBHOOK_PORT}"


### PR DESCRIPTION
Switch from CSV-based scaling to using OpenStack CR operatorOverrides
  feature for scaling down the swift operator. This avoids the need
  to disable the openstack init operator and provides better integration
  with the OpenStack operator management system.