### PR TITLE
Set service_type in [keystone_authtoken] for access rule validation

### DIFF
--- a/templates/swiftproxy/config/00-proxy-server.conf
+++ b/templates/swiftproxy/config/00-proxy-server.conf
@@ -97,6 +97,7 @@ project_name = service
 {{ if (index . "KeystoneRegion") -}}
 region_name = {{ .KeystoneRegion }}
 {{ end -}}
+service_type = object-store
 delay_auth_decision = True
 
 [filter:s3api]


### PR DESCRIPTION
Without service_type configured, keystonemiddleware cannot validate application credentials with custom access rules, causing HTTP 401 for end users.

Closes: [OSPRH-22365](https://redhat.atlassian.net/browse/OSPRH-22365)