### PR TITLE
Fix client IP logging in Keystone API VirtualHost

### DIFF
--- a/templates/swiftproxy/config/httpd.conf
+++ b/templates/swiftproxy/config/httpd.conf
@@ -32,7 +32,9 @@ TimeOut {{ .APITimeout }}
   ## Logging
   ErrorLog /dev/stdout
   ServerSignature Off
-  CustomLog /dev/stdout combined
+  SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+  CustomLog /dev/stdout combined env=!forwarded
+  CustomLog /dev/stdout proxy env=forwarded
 
   ## Request header rules
   ## as per http://httpd.apache.org/docs/2.2/mod/mod_headers.html#requestheader


### PR DESCRIPTION
The `VirtualHost` `CustomLog` directive was overriding the server-level dual-log setup, causing all requests to be logged with the OpenShift router IP instead of the real client IP from `X-Forwarded-For`.

Add `SetEnvIf` and dual `CustomLog` lines inside the `VirtualHost` block to match the `nova-operator` pattern.

Jira: [OSPRH-32108](https://redhat.atlassian.net/browse/OSPRH-32108)