### PR TITLE
Remove deprecated webhook.Defaulter/Validator interface assertions

### DIFF
--- a/api/v1beta1/swift_webhook.go
+++ b/api/v1beta1/swift_webhook.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -48,8 +47,6 @@ func SetupSwiftDefaults(defaults SwiftDefaults) {
 	swiftDefaults = defaults
 	swiftlog.Info("Swift defaults initialized", "defaults", defaults)
 }
-
-var _ webhook.Defaulter = &Swift{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *Swift) Default() {
@@ -100,8 +97,6 @@ func (spec *SwiftSpec) Default() {
 func (spec *SwiftSpecCore) Default() {
 	// nothing here yet
 }
-
-var _ webhook.Validator = &Swift{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Swift) ValidateCreate() (admission.Warnings, error) {

--- a/api/v1beta1/swiftproxy_webhook.go
+++ b/api/v1beta1/swiftproxy_webhook.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -43,8 +42,6 @@ func SetupSwiftProxyDefaults(defaults SwiftProxyDefaults) {
 	swiftProxyDefaults = defaults
 	swiftproxylog.Info("SwiftProxy defaults initialized", "defaults", defaults)
 }
-
-var _ webhook.Defaulter = &SwiftProxy{}
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *SwiftProxy) Default() {
@@ -64,8 +61,6 @@ func (spec *SwiftProxySpecCore) Default() {
 	// Migration from deprecated fields is handled by openstack-operator
 	// This ensures users make a conscious choice about which cluster to use for notifications
 }
-
-var _ webhook.Validator = &SwiftProxy{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *SwiftProxy) ValidateCreate() (admission.Warnings, error) {


### PR DESCRIPTION
These compile-time assertions reference webhook.Defaulter and webhook.Validator interfaces that are removed in controller-runtime v0.21 (OCP 4.20). The assertions are dead code — webhook registration already uses CustomDefaulter/CustomValidator in internal/webhook/.

Removing them makes the API module forward-compatible with CR v0.21 so that consumers (like openstack-operator) can bump controller-runtime without needing replace directives for this operator.